### PR TITLE
Add `Spina::Link` type

### DIFF
--- a/PAGE_PARTS.md
+++ b/PAGE_PARTS.md
@@ -1,0 +1,127 @@
+# Page parts
+
+There are several code building blocks that can be used to create content in
+Spina.
+
+- `Spina::Line`
+- `Spina::Text`
+- `Spina::Photo`
+- `Spina::PhotoCollection`
+- `Spina::Structure`
+- `Spina::Option`
+
+## `Spina::Line`
+
+This is a single line of text. To add one to your template:
+
+    ::Spina::Theme.register do |theme|
+
+      theme.name = 'default'
+      theme.title = 'Default Theme'
+
+      theme.page_parts = [{
+        name:           'text',
+        title:          'Text',
+        partable_type:  'Spina::Text'
+      }]
+
+      theme.view_templates = [{
+          name:       'banner_page',
+          title:      'Banner Page',
+          page_parts: ['text']
+        }
+      # other stuff...
+
+    end
+
+You can now edit this line as the field `Text` for page types `Banner Page`.
+
+To consume this in your view template:
+
+    = @page.content(:text).try(:html_safe)
+
+## `Spina::Text`
+
+**TBC**
+
+## `Spina::Photo`
+
+**TBC**
+
+## `Spina::PhotoCollection`
+
+**TBC**
+
+## `Spina::Structure`
+
+**TBC**
+
+## `Spina::Option`
+
+The `Spina::Option` type allows you to specify a pick-list of options. For example,
+to add a page part that permits the editor to select between Red, Green and Blue:
+
+    ::Spina::Theme.register do |theme|
+
+      theme.name = 'default'
+      theme.title = 'Default Theme'
+
+      theme.page_parts = [{
+        name:           'colour',
+        title:          'Colour',
+        partable_type:  'Spina::Option',
+        options: {
+          values: ['Red', 'Green', 'Blue']
+        }
+      ]
+
+      theme.view_templates = [{
+          name:       'bright_page',
+          title:      'Bright Page',
+          page_parts: ['colour']
+        }
+      # other stuff...
+
+    end
+
+And then to use this you'll need to add translations for each option in your locales file:
+
+    en:
+      options:
+        colour:
+          Green: 'Green'
+          Red: 'Red'
+          Blue: 'Blue'
+
+Then in the template:
+
+    = @page.content(:colour)
+
+## `Spina::Link`
+
+The `Spina::Link` type allows you to create a simple link to another page on the site.
+
+    ::Spina::Theme.register do |theme|
+
+      theme.name = 'default'
+      theme.title = 'Default Theme'
+
+      theme.page_parts = [{
+        name:           'link',
+        title:          'Link',
+        partable_type:  'Spina::Link',
+      ]
+
+      theme.view_templates = [{
+          name:       'link_page',
+          title:      'Link Page',
+          page_parts: ['link']
+        }
+      # other stuff...
+
+    end
+
+In the admin interface, you will now be able to pick from published pages, and add a link title.
+To consume in you templates:
+
+    = link_to @page.content(:link).title, @page.content(:link).materialized_path

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A page in Spina has many Page parts. By default these page parts can be one of t
 - `Spina::PhotoCollection`
 - `Spina::Structure`
 - `Spina::Option`
+- `Spina::Link`
 
 These are the building blocks of your view templates. You can have an unlimited number of page parts in a page. We prefer to keep the number of parts to a minimum so that managing your pages won't become too complex.
 

--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -555,7 +555,7 @@ input.datepicker
   select
     background-color: transparent
     background-image: none
-    border: none
+    border: sold red 5px
     box-shadow: none
     color: #666
     cursor: pointer

--- a/app/models/spina/link.rb
+++ b/app/models/spina/link.rb
@@ -1,0 +1,21 @@
+module Spina
+  class Link < ApplicationRecord
+    has_many :page_parts, as: :page_partable
+    has_many :layout_parts, as: :layout_partable
+    has_many :structure_parts, as: :structure_partable
+    belongs_to :page
+
+    delegate :materialized_path, to: :page
+    alias link materialized_path
+
+    def content
+      self
+    end
+
+    private
+
+    def part
+      page_part || layout_part || structure_part
+    end
+  end
+end

--- a/app/views/spina/admin/page_partables/links/_form.html.haml
+++ b/app/views/spina/admin/page_partables/links/_form.html.haml
@@ -1,0 +1,8 @@
+.horizontal-form-label
+  = f.object.title
+= f.fields_for :page_partable, f.object.page_partable do |ff|
+  .horizontal-form-content
+    .select-dropdown
+      = ff.select :page_id, Spina::Page.live.map {|o| [o.title, o.id]}, prompt: true
+  .horizontal-form-content
+    = ff.text_field :title, placeholder: "#{t 'spina.pages.page_part'} #{f.object.name.downcase}"

--- a/db/migrate/7_create_spina_links.rb
+++ b/db/migrate/7_create_spina_links.rb
@@ -1,0 +1,9 @@
+class CreateSpinaLinks < ActiveRecord::Migration[5.0]
+  def change
+    create_table :spina_links do |t|
+      t.integer :page_id, null: false
+      t.string :title
+      t.timestamps
+    end
+  end
+end

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "0.11.1"
+  VERSION = "0.11.2"
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -72,6 +72,13 @@ ActiveRecord::Schema.define(version: 20170507153143) do
     t.datetime "updated_at"
   end
 
+  create_table "spina_links", force: :cascade do |t|
+    t.integer  "page_id",     null: false
+    t.string   "title"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "spina_navigation_items", force: :cascade do |t|
     t.integer  "page_id",                   null: false
     t.integer  "navigation_id",             null: false


### PR DESCRIPTION
I've only started using Spina in the last week, but I'm finding it a little tricky without this type to do what I want. I want to open an issue to suggest this, but I thought it would be nice to submit some code that suggests a possible solution?

This is to allow you to easily select a page on the site, with a title to generate a lind. This is useful for creating content blocks with (for example) an image, a line of text, and link button that leads to another
page.

I'm not totally happy with the way this is rendered in the UI, nor the `Spina::Link` model - but it's a start.

I'm also a bit at a loss as to how to test this.
