### PR TITLE
Fix JavaScript error that is thrown when a document is uploaded

### DIFF
--- a/app/assets/javascripts/spina/admin/uploads.coffee
+++ b/app/assets/javascripts/spina/admin/uploads.coffee
@@ -3,8 +3,8 @@ $.fn.uploadPhoto = ->
   $(this).fileupload
     dataType: "script"
     singleFileUploads: true
+    replaceFileInput: true
     dropZone: $(this).find('.photo-field')
-    # maxNumberOfFiles: 1
     add: (e, data) ->
       types = /(\.|\/)(gif|jpe?g|png)$/i
       file = data.files[0]


### PR DESCRIPTION
When uploading a new document or image, the following JavaScript error is produced:

```
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?
    at remove (http://rails.dev:9005/assets/jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:6122:20)
    at jQuery.fn.init.detach (http://rails.dev:9005/assets/jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:6252:10)
    at $.(anonymous function).(anonymous function)._replaceFileInput (http://rails.dev:9005/assets/jquery-fileupload/jquery.fileupload.self-79c95…273d5a8955a6093f4f489dcd509c5a2cefb2b9a049d3cdb2710ec8d3.js?body=1:1057:37)
    at $.(anonymous function).(anonymous function)._replaceFileInput (http://rails.dev:9005/assets/jquery-fileupload/vendor/jquery.ui.widget.self…1e67e528eecf100716907331b4b9aa4f546bf75ef2e0529c8c03a562d.js?body=1:128:25)
    at Object.<anonymous> (http://rails.dev:9005/assets/jquery-fileupload/jquery.fileupload.self-79c95…273d5a8955a6093f4f489dcd509c5a2cefb2b9a049d3cdb2710ec8d3.js?body=1:1229:26)
    at fire (http://rails.dev:9005/assets/jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:3233:31)
    at Object.add [as done] (http://rails.dev:9005/assets/jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:3292:7)
    at Object.always (http://rails.dev:9005/assets/jquery.self-bd7ddd393353a8d2480a622e80342adf488fb6006d667e8b42e4c0073393abee.js?body=1:3401:15)
    at $.(anonymous function).(anonymous function)._onChange (http://rails.dev:9005/assets/jquery-fileupload/jquery.fileupload.self-79c95…273d5a8955a6093f4f489dcd509c5a2cefb2b9a049d3cdb2710ec8d3.js?body=1:1226:53)
    at $.(anonymous function).(anonymous function)._onChange (http://rails.dev:9005/assets/jquery-fileupload/vendor/jquery.ui.widget.self…1e67e528eecf100716907331b4b9aa4f546bf75ef2e0529c8c03a562d.js?body=1:128:25)
remove @ jquery.self-bd7ddd3….js?body=1:6122
detach @ jquery.self-bd7ddd3….js?body=1:6252
_replaceFileInput @ jquery.fileupload.self-79c952f….js?body=1:1057
(anonymous) @ jquery.ui.widget.self-92c37a4….js?body=1:128
(anonymous) @ jquery.fileupload.self-79c952f….js?body=1:1229
fire @ jquery.self-bd7ddd3….js?body=1:3233
add @ jquery.self-bd7ddd3….js?body=1:3292
always @ jquery.self-bd7ddd3….js?body=1:3401
_onChange @ jquery.fileupload.self-79c952f….js?body=1:1226
(anonymous) @ jquery.ui.widget.self-92c37a4….js?body=1:128
handlerProxy @ jquery.ui.widget.self-92c37a4….js?body=1:439
dispatch @ jquery.self-bd7ddd3….js?body=1:5227
elemData.handle @ jquery.self-bd7ddd3….js?body=1:4879
```

which is probably a bug in jquery-fileupload. This is due to [this value](https://github.com/blueimp/jQuery-File-Upload/wiki/Options#replacefileinput) being true by default, so as a workaround I've disabled this value, following the discussion in [this issue](https://github.com/denkGroot/Spina/issues/234)

Let me know what you think