### PR TITLE
Show logo if one exists

### DIFF
--- a/app/views/spina/admin/accounts/style.html.haml
+++ b/app/views/spina/admin/accounts/style.html.haml
@@ -6,7 +6,7 @@
       %button.button.button-primary{type: 'submit', data: {icon: 'o'}}
         = icon('check')
         = t('spina.preferences.style_save')
-        
+
   .well
     .horizontal-form
       .horizontal-form-group
@@ -20,7 +20,7 @@
         .horizontal-form-label
           = Spina::Account.human_attribute_name(:logo)
         .horizontal-form-content
-          = image_tag current_account.logo
+          = image_tag current_account.logo.url if current_account.logo.present?
           = f.file_field :logo
 
       = f.fields_for :layout_parts do |ff|


### PR DESCRIPTION
This PR does two things:

First, resolves an undefined method `to_model` error that occurs when trying to load the image without calling `.url`

Second, only tries to load the image if there is a logo on the model.