### PR TITLE
Make photo and photo_collection optional on join

### DIFF
--- a/app/models/spina/photo_collections_photo.rb
+++ b/app/models/spina/photo_collections_photo.rb
@@ -1,6 +1,6 @@
 module Spina
   class PhotoCollectionsPhoto < ApplicationRecord
-    belongs_to :photo
-    belongs_to :photo_collection
+    belongs_to :photo, optional: true
+    belongs_to :photo_collection, optional: true
   end
 end


### PR DESCRIPTION
Sometimes you can't save a page without adding an image to a photo or photo_collection page part so this makes it optional.

```
Oops! Something went wrong
Page parts page partable photo collections photos photo must exist
```