### PR TITLE
Extend Mobility in each translated model instead of ApplicationRecord

### DIFF
--- a/app/models/spina/application_record.rb
+++ b/app/models/spina/application_record.rb
@@ -1,7 +1,5 @@
 module Spina
   class ApplicationRecord < ActiveRecord::Base
-    extend Mobility
-    
     self.abstract_class = true
   end
 end

--- a/app/models/spina/line.rb
+++ b/app/models/spina/line.rb
@@ -1,5 +1,6 @@
 module Spina
   class Line < ApplicationRecord
+    extend Mobility
     translates :content
 
     has_many :page_parts, as: :page_partable

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -1,5 +1,6 @@
 module Spina
   class Page < ApplicationRecord
+    extend Mobility
     include Partable
 
     # Stores the old path when generating a new materialized_path

--- a/app/models/spina/text.rb
+++ b/app/models/spina/text.rb
@@ -1,5 +1,6 @@
 module Spina
   class Text < ApplicationRecord
+    extend Mobility
     translates :content
     
     has_many :page_parts, as: :page_partable


### PR DESCRIPTION
Issues like the one in #346 can be caused by extending `Mobility` in ApplicationRecord. But also, it's generally better to only extend models that need translations with Mobility, and since there are only three, it's just a couple extra lines of code.