### PR TITLE
Support for Spina::Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,22 @@ The installer will help you setup your first user.
 
 Then start `rails s` and access Spina at `/admin`.
 
-## Upgrading from 0.12 to 1.0.0.alpha
+## Upgrading from 0.13 to 1.0.0.alpha
 
-Going from 0.12 to 1.0 will introduce a couple of changes. Globalize is replaced by Mobility and later down the road CarrierWave will be replaced by Rails' ActiveStorage. 
+Going from 0.13 to 1.0 will introduce a couple of changes. Globalize is replaced by Mobility and later down the road CarrierWave will be replaced by Rails' ActiveStorage. 
 
 Switching to Mobility is fairly straightfoward. 
 - Run `rails g spina:install` to add the `mobility.rb` initializer.
 - Replace instances of `Globalize` with `Mobility` in your own code
+
+## Upgrading from 0.12 to 0.13
+
+Simply run the new migrations
+
+    rails spina:install:migrations
+    rails db:migrate
+
+This will create a table for the `Spina::Resource` model.
 
 ## Upgrading from 0.11 to 0.12
 

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -12,7 +12,7 @@ module Spina
 
       def new
         @resource = Resource.find_by(id: params[:resource_id])
-        @page = Page.new(resource: @resource, parent: @resource.parent_page)
+        @page = Page.new(resource: @resource, parent: @resource&.parent_page)
         add_index_breadcrumb
         if current_theme.new_page_templates.any? { |template| template[0] == params[:view_template] }
           @page.view_template = params[:view_template]

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -7,12 +7,12 @@ module Spina
       def index
         add_breadcrumb I18n.t('spina.website.pages'), spina.admin_pages_path
         redirect_to admin_pages_path unless current_admin_path.starts_with?('/pages')
-        @pages = Page.active.sorted.roots.where(resource: nil)
+        @pages = Page.active.sorted.roots.regular_pages
       end
 
       def new
         @resource = Resource.find_by(id: params[:resource_id])
-        @page = Page.new(resource: @resource)
+        @page = Page.new(resource: @resource, parent: @resource.parent_page)
         add_index_breadcrumb
         if current_theme.new_page_templates.any? { |template| template[0] == params[:view_template] }
           @page.view_template = params[:view_template]

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -1,17 +1,19 @@
 module Spina
   module Admin
     class PagesController < AdminController
-      before_action :set_breadcrumb
       before_action :set_tabs, only: [:new, :create, :edit, :update]
       before_action :set_locale
 
       def index
+        add_breadcrumb I18n.t('spina.website.pages'), spina.admin_pages_path
         redirect_to admin_pages_path unless current_admin_path.starts_with?('/pages')
-        @pages = Page.active.sorted.roots
+        @pages = Page.active.sorted.roots.where(resource: nil)
       end
 
       def new
-        @page = Page.new
+        @resource = Resource.find_by(id: params[:resource_id])
+        @page = Page.new(resource: @resource)
+        add_index_breadcrumb
         if current_theme.new_page_templates.any? { |template| template[0] == params[:view_template] }
           @page.view_template = params[:view_template]
         end
@@ -34,6 +36,7 @@ module Spina
 
       def edit
         @page = Page.find(params[:id])
+        add_index_breadcrumb
         add_breadcrumb @page.title
         @page_parts = @page.view_template_page_parts(current_theme).map { |part| @page.part(part) }
         render layout: 'spina/admin/admin'
@@ -78,8 +81,12 @@ module Spina
         @locale = params[:locale] || I18n.default_locale
       end
 
-      def set_breadcrumb
-        add_breadcrumb I18n.t('spina.website.pages'), spina.admin_pages_path
+      def add_index_breadcrumb
+        if @page.resource.present?
+          add_breadcrumb @page.resource.label, spina.admin_resource_path(@page.resource)
+        else
+          add_breadcrumb I18n.t('spina.website.pages'), spina.admin_pages_path
+        end
       end
 
       def set_tabs

--- a/app/controllers/spina/admin/resources_controller.rb
+++ b/app/controllers/spina/admin/resources_controller.rb
@@ -1,0 +1,12 @@
+module Spina
+  module Admin
+    class ResourcesController < AdminController
+
+      def show
+        @resource = Resource.find(params[:id])
+        add_breadcrumb @resource.label
+      end
+
+    end
+  end
+end

--- a/app/controllers/spina/admin/resources_controller.rb
+++ b/app/controllers/spina/admin/resources_controller.rb
@@ -7,6 +7,27 @@ module Spina
         add_breadcrumb @resource.label
       end
 
+      def edit
+        @resource = Resource.find(params[:id])
+        add_breadcrumb @resource.label, spina.admin_resource_path(@resource)
+        add_breadcrumb t('spina.edit')
+      end
+
+      def update
+        @resource = Resource.find(params[:id])
+        if @resource.update_attributes(resource_params)
+          redirect_to spina.admin_resource_path(@resource)
+        else
+          render :edit
+        end
+      end
+
+      private
+
+        def resource_params
+          params.require(:resource).permit(:label, :view_template, :order_by, :parent_page_id)
+        end
+
     end
   end
 end

--- a/app/helpers/spina/admin/pages_helper.rb
+++ b/app/helpers/spina/admin/pages_helper.rb
@@ -37,7 +37,7 @@ module Spina
 
       def page_ancestry_options(page)
         pages = Spina::Page.active.regular_pages
-        pages = pages.where.not(id: page.subtree.ids) unless page.new_record?
+        pages = pages.where.not(id: page.subtree.ids) unless page.new_record? || !page.methods.include?(:subtree)
 
         flatten_nested_hash(pages.arrange(order: :position)).map do |page|
           next if page.depth >= Spina.config.max_page_depth - 1

--- a/app/helpers/spina/admin/pages_helper.rb
+++ b/app/helpers/spina/admin/pages_helper.rb
@@ -36,7 +36,7 @@ module Spina
       end
 
       def page_ancestry_options(page)
-        pages = Spina::Page.active
+        pages = Spina::Page.active.regular_pages
         pages = pages.where.not(id: page.subtree.ids) unless page.new_record?
 
         flatten_nested_hash(pages.arrange(order: :position)).map do |page|

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -21,6 +21,8 @@ module Spina
     # Pages can belong to a resource
     belongs_to :resource, optional: true
 
+    scope :regular_pages, ->  { where(resource: nil) }
+    scope :resource_pages, -> { where.not(resource: nil) }
     scope :active, -> { where(active: true) }
     scope :sorted, -> { order(:position) }
     scope :live, -> { active.where(draft: false) }

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -18,6 +18,9 @@ module Spina
     has_many :navigation_items, dependent: :destroy
     has_many :navigations, through: :navigation_items
 
+    # Pages can belong to a resource
+    belongs_to :resource, optional: true
+
     scope :active, -> { where(active: true) }
     scope :sorted, -> { order(:position) }
     scope :live, -> { active.where(draft: false) }

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -1,0 +1,5 @@
+module Spina
+  class Resource < ApplicationRecord
+    has_many :pages, dependent: :restrict_with_exception
+  end
+end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -1,5 +1,7 @@
 module Spina
   class Resource < ApplicationRecord
     has_many :pages, dependent: :restrict_with_exception
+
+    belongs_to :parent_page, class_name: "Spina::Page"
   end
 end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -2,6 +2,15 @@ module Spina
   class Resource < ApplicationRecord
     has_many :pages, dependent: :restrict_with_exception
 
-    belongs_to :parent_page, class_name: "Spina::Page"
+    belongs_to :parent_page, class_name: "Spina::Page", optional: true
+
+    def pages
+      case order_by
+      when "title"
+        super.joins(:translations).where(spina_page_translations: {locale: I18n.locale}).order("spina_page_translations.title")
+      else
+        super.order(created_at: :desc)
+      end
+    end
   end
 end

--- a/app/views/layouts/spina/admin/resources.html.haml
+++ b/app/views/layouts/spina/admin/resources.html.haml
@@ -1,0 +1,10 @@
+- content_for :application do
+  %header#header
+    #header_actions
+      = yield(:header_actions)
+
+    = render partial: 'spina/admin/shared/breadcrumbs'
+
+  = yield
+
+= render template: "layouts/spina/admin/admin"

--- a/app/views/spina/admin/navigations/_page.html.haml
+++ b/app/views/spina/admin/navigations/_page.html.haml
@@ -4,5 +4,5 @@
       = check_box_tag 'navigation[page_ids][]', page.id, @navigation.page_ids.include?(page.id)
       = label_tag page.title
 
-- if page.children.any?
-  = render partial: 'page', collection: page.children.sorted.where(resource: nil)
+- if page.children.regular_pages.any?
+  = render partial: 'page', collection: page.children.sorted.regular_pages

--- a/app/views/spina/admin/navigations/_page.html.haml
+++ b/app/views/spina/admin/navigations/_page.html.haml
@@ -5,4 +5,4 @@
       = label_tag page.title
 
 - if page.children.any?
-  = render partial: 'page', collection: page.children.sorted
+  = render partial: 'page', collection: page.children.sorted.where(resource: nil)

--- a/app/views/spina/admin/navigations/edit.html.haml
+++ b/app/views/spina/admin/navigations/edit.html.haml
@@ -10,7 +10,7 @@
   .well
     .table-container
       %table.table.table-clickable
-        %tbody= render partial: 'page', collection: Spina::Page.sorted.roots
+        %tbody= render partial: 'page', collection: Spina::Page.sorted.roots.where(resource: nil)
 
   .well
     .horizontal-form

--- a/app/views/spina/admin/navigations/edit.html.haml
+++ b/app/views/spina/admin/navigations/edit.html.haml
@@ -10,7 +10,7 @@
   .well
     .table-container
       %table.table.table-clickable
-        %tbody= render partial: 'page', collection: Spina::Page.sorted.roots.where(resource: nil)
+        %tbody= render partial: 'page', collection: Spina::Page.sorted.roots.regular_pages
 
   .well
     .horizontal-form

--- a/app/views/spina/admin/pages/_form_advanced.html.haml
+++ b/app/views/spina/admin/pages/_form_advanced.html.haml
@@ -45,3 +45,10 @@
       .horizontal-form-content
         .select-dropdown.ancestry
           = f.select :parent_id, page_ancestry_options(f.object), include_blank: Spina::Page.human_attribute_name(:no_parent)
+
+    .horizontal-form-group
+      .horizontal-form-label
+        = Spina::Page.human_attribute_name :resource
+      .horizontal-form-content
+        .select-dropdown
+          = f.select :resource_id, Spina::Resource.pluck(:label, :id), include_blank: Spina::Page.human_attribute_name(:no_resource)

--- a/app/views/spina/admin/pages/_form_advanced.html.haml
+++ b/app/views/spina/admin/pages/_form_advanced.html.haml
@@ -1,54 +1,57 @@
-#advanced.tab-content.well
+#advanced.tab-content
   .horizontal-form
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :draft
-        %small= Spina::Page.human_attribute_name :draft_description
-      .horizontal-form-content
-        = f.check_box :draft, data: {switch: true}
+    .well
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :draft
+          %small= Spina::Page.human_attribute_name :draft_description
+        .horizontal-form-content
+          = f.check_box :draft, data: {switch: true}
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :show_in_menu
+          %small= Spina::Page.human_attribute_name :show_in_menu_description
+        .horizontal-form-content
+          = f.check_box :show_in_menu, data: {switch: true}
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :menu_title
+        .horizontal-form-content
+          = f.text_field :menu_title, placeholder: Spina::Page.human_attribute_name(:show_in_menu_placeholder), value: f.object.menu_title(fallback: false, default: nil)
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :skip_to_first_child
+          %small= Spina::Page.human_attribute_name :skip_to_first_child_description
+        .horizontal-form-content
+          = f.check_box :skip_to_first_child, data: {switch: true}
 
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :skip_to_first_child
-        %small= Spina::Page.human_attribute_name :skip_to_first_child_description
-      .horizontal-form-content
-        = f.check_box :skip_to_first_child, data: {switch: true}
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :link_url
-        %small= Spina::Page.human_attribute_name :link_url_description
-      .horizontal-form-content
-        = f.text_field :link_url, placeholder: Spina::Page.human_attribute_name(:link_url_placeholder)
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :show_in_menu
-        %small= Spina::Page.human_attribute_name :show_in_menu_description
-      .horizontal-form-content
-        = f.check_box :show_in_menu, data: {switch: true}
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :menu_title
-      .horizontal-form-content
-        = f.text_field :menu_title, placeholder: Spina::Page.human_attribute_name(:show_in_menu_placeholder), value: f.object.menu_title(fallback: false, default: nil)
+    .well
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :link_url
+          %small= Spina::Page.human_attribute_name :link_url_description
+        .horizontal-form-content
+          = f.text_field :link_url, placeholder: Spina::Page.human_attribute_name(:link_url_placeholder)
 
-    .horizontal-form-group{style: ('display: none' if @page.custom_page?)}
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :view_template
-      .horizontal-form-content
-        .select-dropdown.page-template{data: {page_parts: @page.view_template_config(current_theme)[:page_parts]}}
-          - options = options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name], {'data-page-parts' => template[:page_parts]}] }, @page.view_template)
-          = f.select :view_template, options
+    .well
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :ancestry
+        .horizontal-form-content
+          .select-dropdown.ancestry
+            = f.select :parent_id, page_ancestry_options(f.object), include_blank: Spina::Page.human_attribute_name(:no_parent)
 
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :ancestry
-      .horizontal-form-content
-        .select-dropdown.ancestry
-          = f.select :parent_id, page_ancestry_options(f.object), include_blank: Spina::Page.human_attribute_name(:no_parent)
+      .horizontal-form-group{style: ('display: none' if @page.custom_page?)}
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :view_template
+        .horizontal-form-content
+          .select-dropdown.page-template{data: {page_parts: @page.view_template_config(current_theme)[:page_parts]}}
+            - options = options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name], {'data-page-parts' => template[:page_parts]}] }, @page.view_template)
+            = f.select :view_template, options
 
-    .horizontal-form-group
-      .horizontal-form-label
-        = Spina::Page.human_attribute_name :resource
-      .horizontal-form-content
-        .select-dropdown
-          = f.select :resource_id, Spina::Resource.pluck(:label, :id), include_blank: Spina::Page.human_attribute_name(:no_resource)
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :resource
+        .horizontal-form-content
+          .select-dropdown
+            = f.select :resource_id, Spina::Resource.order(:label).pluck(:label, :id), include_blank: t('spina.website.pages')

--- a/app/views/spina/admin/pages/_page_nested_list.html.haml
+++ b/app/views/spina/admin/pages/_page_nested_list.html.haml
@@ -1,7 +1,7 @@
 %li.dd-item{data: {id: page_nested_list.id}}
-  %div.dd-item-inner
+  .dd-item-inner
     = render partial: 'spina/admin/pages/page', object: page_nested_list
 
-  - if page_nested_list.children.active.present?
+  - if page_nested_list.children.active.regular_pages.any?
     %ol.dd-list
-      = render partial: 'spina/admin/pages/page_nested_list', collection: page_nested_list.children.active.sorted
+      = render partial: 'spina/admin/pages/page_nested_list', collection: page_nested_list.children.active.sorted.regular_pages

--- a/app/views/spina/admin/pages/_page_nested_list.html.haml
+++ b/app/views/spina/admin/pages/_page_nested_list.html.haml
@@ -1,7 +1,7 @@
 %li.dd-item{data: {id: page_nested_list.id}}
   %div.dd-item-inner
-    = render partial: 'page', object: page_nested_list
+    = render partial: 'spina/admin/pages/page', object: page_nested_list
 
   - if page_nested_list.children.active.present?
     %ol.dd-list
-      = render partial: 'page_nested_list', collection: page_nested_list.children.active.sorted
+      = render partial: 'spina/admin/pages/page_nested_list', collection: page_nested_list.children.active.sorted

--- a/app/views/spina/admin/pages/_page_nested_list.html.haml
+++ b/app/views/spina/admin/pages/_page_nested_list.html.haml
@@ -1,7 +1,7 @@
 %li.dd-item{data: {id: page_nested_list.id}}
   .dd-item-inner
-    = render partial: 'spina/admin/pages/page', object: page_nested_list
+    = render partial: 'page', object: page_nested_list
 
   - if page_nested_list.children.active.regular_pages.any?
     %ol.dd-list
-      = render partial: 'spina/admin/pages/page_nested_list', collection: page_nested_list.children.active.sorted.regular_pages
+      = render partial: 'page_nested_list', collection: page_nested_list.children.active.sorted.regular_pages

--- a/app/views/spina/admin/pages/index.html.haml
+++ b/app/views/spina/admin/pages/index.html.haml
@@ -32,4 +32,4 @@
 .well
   .dd#pages_list{data: {:"sort-url" => spina.sort_admin_pages_url }}
     %ol.dd-list
-      = render partial: 'page_nested_list', collection: @pages.roots
+      = render partial: 'page_nested_list', collection: @pages

--- a/app/views/spina/admin/resources/edit.html.haml
+++ b/app/views/spina/admin/resources/edit.html.haml
@@ -1,0 +1,49 @@
+- if @resource.errors.any?
+  - content_for :notifications do
+    .notification.notification-danger.animated.fadeInRight
+      = icon('exclamation')
+      .notification-message
+        =t 'spina.notifications.alert'
+        %small= @resource.errors.full_messages.join('<br />').html_safe
+      = link_to '#', data: {close_notification: true} do
+        = icon('cross')
+
+= form_with model: @resource, url: spina.admin_resource_path(@resource) do |f|
+  %header#header
+    .breadcrumbs= render_breadcrumbs separator: '<div class="divider"></div>'
+
+    #header_actions
+      %button.button.button-primary{type: 'submit', style: 'margin-right: 0'}
+        = icon('check')
+        =t 'spina.save'
+
+  .well
+    .horizontal-form
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Resource.human_attribute_name :label
+        .horizontal-form-content
+          = f.text_field :label, placeholder: Spina::Resource.human_attribute_name(:label)
+
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Resource.human_attribute_name :order_by
+        .horizontal-form-content
+          .select-dropdown
+            - options = [[Spina::Page.human_attribute_name(:title), 'title']]
+            = f.select :order_by, options_for_select(options, f.object.order_by), include_blank: Spina::Page.human_attribute_name(:created_at)
+
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Resource.human_attribute_name :view_template
+        .horizontal-form-content
+          .select-dropdown
+            - options = options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name]] }, @resource.view_template)
+            = f.select :view_template, options, include_blank: true
+
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Resource.human_attribute_name :parent_page
+        .horizontal-form-content
+          .select-dropdown
+            = f.select :parent_page_id, page_ancestry_options(f.object), include_blank: Spina::Resource.human_attribute_name(:no_parent)

--- a/app/views/spina/admin/resources/show.html.haml
+++ b/app/views/spina/admin/resources/show.html.haml
@@ -1,0 +1,8 @@
+- content_for(:header_actions) do
+  = link_to spina.new_admin_page_path(params: {resource_id: @resource.id, view_template: 'landings_page'}), class: 'button icon-only', style: 'margin-right: 0' do
+    = icon('plus')
+
+.well
+  .dd#pages_list
+    %ol.dd-list
+      = render partial: 'spina/admin/pages/page_nested_list', collection: @resource.pages

--- a/app/views/spina/admin/resources/show.html.haml
+++ b/app/views/spina/admin/resources/show.html.haml
@@ -5,4 +5,6 @@
 .well
   .dd#pages_list
     %ol.dd-list
-      = render partial: 'spina/admin/pages/page_nested_list', collection: @resource.pages
+      - @resource.pages.each do |page|
+        %li.dd-item
+          .dd-item-inner= render partial: 'spina/admin/pages/page', object: page

--- a/app/views/spina/admin/resources/show.html.haml
+++ b/app/views/spina/admin/resources/show.html.haml
@@ -1,5 +1,5 @@
 - content_for(:header_actions) do
-  = link_to spina.new_admin_page_path(params: {resource_id: @resource.id, view_template: 'landings_page'}), class: 'button icon-only', style: 'margin-right: 0' do
+  = link_to spina.new_admin_page_path(params: {resource_id: @resource.id, view_template: @resource.view_template.presence || 'show'}), class: 'button icon-only', style: 'margin-right: 0' do
     = icon('plus')
 
 .well

--- a/app/views/spina/admin/resources/show.html.haml
+++ b/app/views/spina/admin/resources/show.html.haml
@@ -1,5 +1,9 @@
 - content_for(:header_actions) do
-  = link_to spina.new_admin_page_path(params: {resource_id: @resource.id, view_template: @resource.view_template.presence || 'show'}), class: 'button icon-only', style: 'margin-right: 0' do
+  
+  = link_to spina.edit_admin_resource_path(@resource), class: 'button' do
+    = t('spina.resources.edit')
+
+  = link_to spina.new_admin_page_path(params: {resource_id: @resource.id, view_template: @resource.view_template.presence || 'show'}), class: 'button button-primary icon-only', style: 'margin-right: 0' do
     = icon('plus')
 
 .well

--- a/app/views/spina/admin/shared/_primary_navigation.html.haml
+++ b/app/views/spina/admin/shared/_primary_navigation.html.haml
@@ -1,20 +1,26 @@
 %nav#primary.transformed{data: {turbolinks_permanent: true}}
   %ul
-    %li{class: ('active' if (%w[pages photos attachments navigations] + Spina::Plugin.all.map { |plugin| plugin.namespace if current_theme.plugins.include?(plugin.name) }).include? controller_name)}
+    %li{class: ('active' if (%w[pages photos attachments navigations resources] + Spina::Plugin.all.map { |plugin| plugin.namespace if current_theme.plugins.include?(plugin.name) }).include? controller_name)}
       = link_to spina.admin_pages_path do
         = icon('home')
         = t('spina.website.title')
         = icon('caret-right')
 
       %ul
-        %li{class: ('active' if current_admin_path.start_with?('/pages') || current_admin_path.start_with?('/navigations'))}
+        %li{class: ('active' if (current_admin_path.start_with?('/pages') || current_admin_path.start_with?('/navigations')) && @page&.resource.blank?)}
           = link_to t('spina.website.pages'), spina.admin_pages_path
+
         %li{class: ('active' if current_admin_path.start_with?('/photos', '/attachments'))}
           = link_to t('spina.website.media_library'), spina.admin_photos_path
+
         - Spina::Plugin.all.each do |plugin|
           - if current_theme.plugins.include? plugin.name
             - if lookup_context.exists? "spina/admin/hooks/#{ plugin.namespace }/_website_secondary_navigation"
               = render "spina/admin/hooks/#{ plugin.namespace }/website_secondary_navigation", plugin: plugin
+
+        - Spina::Resource.order(:label).each do |resource|
+          %li{class: ('active' if (@resource || @page&.resource) == resource)}= link_to resource.label, spina.admin_resource_path(resource)
+
         %li
           = link_to '#', class: 'back-to-main-menu' do
             = icon('caret-left')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,9 @@ en:
       saving: Saving...
       saved: Page saved
 
+    resources:
+      edit: Edit resource
+
     users:
       new: New user
       save: Save user
@@ -169,6 +172,7 @@ en:
         size: Size
 
       spina/page:
+        created_at: Created at
         title: Title
         title_placeholder: Page title
         seo_title: SEO <title>
@@ -190,6 +194,12 @@ en:
         view_template: Page template
         ancestry: Parent page
         no_parent: No parent
+
+      spina/resource:
+        label: Label
+        order_by: Order by
+        view_template: Default view template
+        parent_page: Parent page
 
       spina/media_folder:
         name: Name

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -62,6 +62,9 @@ nl:
       saving: <i></i> Opslaan...
       saved: Pagina opgeslagen
 
+    resources:
+      edit: Bewerken
+
     users:
       new: Nieuwe gebruiker
       save: Gebruiker opslaan
@@ -153,10 +156,15 @@ nl:
         size: Grootte
 
       spina/page:
+        created_at: Aangemaakt op
+        ancestry: Bovenliggende pagina
         title: Titel
         title_placeholder: Titel van de pagina
         seo_title: SEO <title>
         seo_title_placeholder: Deze titel komt in de <title>-tag van de broncode te staan
+        link_url: Doorverwijzing
+        link_url_description: Doorverwijzen naar URL
+        link_url_placeholder: bijv. https://www.google.nl/
         description: SEO Beschrijving
         description_description: De beschrijving wordt weergegeven bij resultaten van zoekmachines
         description_placeholder: Een korte beschrijving van de pagina
@@ -169,6 +177,13 @@ nl:
         menu_title: Menu titel
         menu_title_placeholder: Leeglaten om de titel van de pagina over te nemen
         view_template: Pagina template
+        resource: Weergeven in
+
+      spina/resource:
+        label: Label
+        order_by: Sorteer overzicht
+        view_template: Standaard pagina template
+        parent_page: Bovenliggende pagina
 
       spina/navigation:
         label: Label

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Spina::Engine.routes.draw do
       post :sort, on: :collection
     end
 
-    resources :resources, only: [:show]
+    resources :resources, only: [:show, :edit, :update]
 
     resources :navigations do
       post :sort, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Spina::Engine.routes.draw do
       post :sort, on: :collection
     end
 
+    resources :resources, only: [:show]
+
     resources :navigations do
       post :sort, on: :member
     end

--- a/db/migrate/20180417114925_create_spina_resources.rb
+++ b/db/migrate/20180417114925_create_spina_resources.rb
@@ -5,6 +5,7 @@ class CreateSpinaResources < ActiveRecord::Migration[5.1]
       t.string :label
       t.string :view_template
       t.integer :parent_page_id
+      t.string :order_by
       t.timestamps
     end
     add_column :spina_pages, :resource_id, :integer, null: true

--- a/db/migrate/20180417114925_create_spina_resources.rb
+++ b/db/migrate/20180417114925_create_spina_resources.rb
@@ -1,11 +1,14 @@
 class CreateSpinaResources < ActiveRecord::Migration[5.1]
   def change
     create_table :spina_resources do |t|
-      t.string :name
+      t.string :name, null: false, unique: true
       t.string :label
+      t.string :view_template
+      t.integer :parent_page_id
       t.timestamps
     end
     add_column :spina_pages, :resource_id, :integer, null: true
     add_index :spina_pages, :resource_id
+    add_index :spina_resources, :parent_page_id
   end
 end

--- a/db/migrate/20180417114925_create_spina_resources.rb
+++ b/db/migrate/20180417114925_create_spina_resources.rb
@@ -1,0 +1,11 @@
+class CreateSpinaResources < ActiveRecord::Migration[5.1]
+  def change
+    create_table :spina_resources do |t|
+      t.string :name
+      t.string :label
+      t.timestamps
+    end
+    add_column :spina_pages, :resource_id, :integer, null: true
+    add_index :spina_pages, :resource_id
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,10 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170724115131) do
+ActiveRecord::Schema.define(version: 20180417114925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "spina_accounts", force: :cascade do |t|
     t.string "name"
@@ -47,7 +68,27 @@ ActiveRecord::Schema.define(version: 20170724115131) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "spina_layout_parts", force: :cascade do |t|
+  create_table "spina_image_collections", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "spina_image_collections_images", id: :serial, force: :cascade do |t|
+    t.integer "image_collection_id"
+    t.integer "image_id"
+    t.integer "position"
+    t.index ["image_collection_id"], name: "index_spina_image_collections_images_on_image_collection_id"
+    t.index ["image_id"], name: "index_spina_image_collections_images_on_image_id"
+  end
+
+  create_table "spina_images", force: :cascade do |t|
+    t.integer "media_folder_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["media_folder_id"], name: "index_spina_images_on_media_folder_id"
+  end
+
+  create_table "spina_layout_parts", id: :serial, force: :cascade do |t|
     t.string "title"
     t.string "name"
     t.integer "layout_partable_id"
@@ -57,12 +98,12 @@ ActiveRecord::Schema.define(version: 20170724115131) do
     t.integer "account_id"
   end
 
-  create_table "spina_line_translations", force: :cascade do |t|
+  create_table "spina_line_translations", id: :serial, force: :cascade do |t|
     t.integer "spina_line_id", null: false
     t.string "locale", null: false
+    t.string "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "content"
     t.index ["locale"], name: "index_spina_line_translations_on_locale"
     t.index ["spina_line_id"], name: "index_spina_line_translations_on_spina_line_id"
   end
@@ -114,16 +155,16 @@ ActiveRecord::Schema.define(version: 20170724115131) do
     t.string "page_partable_type"
   end
 
-  create_table "spina_page_translations", force: :cascade do |t|
+  create_table "spina_page_translations", id: :serial, force: :cascade do |t|
     t.integer "spina_page_id", null: false
     t.string "locale", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "title"
     t.string "menu_title"
     t.string "description"
     t.string "seo_title"
     t.string "materialized_path"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["locale"], name: "index_spina_page_translations_on_locale"
     t.index ["spina_page_id"], name: "index_spina_page_translations_on_spina_page_id"
   end
@@ -143,6 +184,8 @@ ActiveRecord::Schema.define(version: 20170724115131) do
     t.string "ancestry"
     t.integer "position"
     t.boolean "active", default: true
+    t.integer "resource_id"
+    t.index ["resource_id"], name: "index_spina_pages_on_resource_id"
   end
 
   create_table "spina_photo_collections", force: :cascade do |t|
@@ -162,6 +205,17 @@ ActiveRecord::Schema.define(version: 20170724115131) do
     t.datetime "updated_at", null: false
     t.integer "media_folder_id"
     t.index ["media_folder_id"], name: "index_spina_photos_on_media_folder_id"
+  end
+
+  create_table "spina_resources", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "label"
+    t.string "view_template"
+    t.integer "parent_page_id"
+    t.string "order_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["parent_page_id"], name: "index_spina_resources_on_parent_page_id"
   end
 
   create_table "spina_rewrite_rules", force: :cascade do |t|
@@ -204,12 +258,12 @@ ActiveRecord::Schema.define(version: 20170724115131) do
     t.datetime "updated_at"
   end
 
-  create_table "spina_text_translations", force: :cascade do |t|
+  create_table "spina_text_translations", id: :serial, force: :cascade do |t|
     t.integer "spina_text_id", null: false
     t.string "locale", null: false
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "content"
     t.index ["locale"], name: "index_spina_text_translations_on_locale"
     t.index ["spina_text_id"], name: "index_spina_text_translations_on_spina_text_id"
   end

--- a/test/factories/resources.rb
+++ b/test/factories/resources.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :resource, class: Spina::Resource do
+
+    factory :breweries do
+      name 'breweries'
+      label 'Breweries'
+    end
+
+  end
+end

--- a/test/integration/spina/admin/resources_test.rb
+++ b/test/integration/spina/admin/resources_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+module Spina
+  module Admin
+    class ResourcesTest < ActionDispatch::IntegrationTest
+      setup do
+        @routes = Engine.routes
+        @account = FactoryGirl.create :account
+        @user = FactoryGirl.create :user
+        @breweries = FactoryGirl.create :breweries
+        post "/admin/sessions", params: {email: @user.email, password: "password"}
+      end
+
+      test "list resources" do
+        get "/admin/resources/#{@breweries.id}"
+        assert_select '.breadcrumbs', text: /\ABreweries/
+      end
+
+      test "new resource page" do
+        get "/admin/pages/new?resource_id=#{@breweries.id}"
+        assert_select "#page_resource_id option[value='#{@breweries.id}'][selected='selected']"
+      end
+
+      test "create new resource page" do
+        post "/admin/pages", params: {page: {title: "Brewery", resource_id: @breweries.id}}
+        follow_redirect!
+        assert_select '.breadcrumbs', text: /Brewery\z/
+        assert_select '.breadcrumbs', text: /\ABreweries/
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Often we'd like to manage things in Spina besides pages. Examples are a portfolio, simple blogposts or (in our case) a list of breweries. Usually we want those to have a URL and page parts, just like pages. So we end up recreating a lot of functionality in a new plugin.

In order to make this a lot easier we'd like to introduce a new model called `Spina::Resource`. 

It's actually quite simple. This model stores a few attributes regarding our resource: `name`, `label`, `view_template`, `order_by`, `parent_page`.

## Example
Say we want to manage a list of breweries (which we do).

We can create a resource like this:
```ruby
Spina::Resource.create(
  name: "breweries", 
  label: "Breweries", 
  order_by: "title", 
  view_template: "brewery"
)
```
This immediately creates a new item in our website navigation:

![schermafbeelding 2018-04-21 om 13 12 59](https://user-images.githubusercontent.com/423116/39083544-be7ac1ac-4565-11e8-8b60-9da3f2589699.png)

When I click on the add button, I'm greeted by a new page form:

![schermafbeelding 2018-04-21 om 13 14 08](https://user-images.githubusercontent.com/423116/39083555-ebe73d0a-4565-11e8-8a35-0f6fc10773ac.png)

This is a page just like any other in Spina, including page parts, URL rewrites and ancestry. The exception is that these pages only show up inside the breweries section of Spina because these pages belong to our newly created resource. 

If we'd like to get our breweries for our frontend we can simply do this:

```ruby
Spina::Resource.find_by(name: "breweries").pages
```

A nice helper could be:

```ruby
def breweries
  @breweries ||= Spina::Resource.where(name: "breweries").first_or_create.pages
end
```