### PR TITLE
Feature/navigation label translations

### DIFF
--- a/app/controllers/spina/admin/admin_controller.rb
+++ b/app/controllers/spina/admin/admin_controller.rb
@@ -23,6 +23,10 @@ module Spina
         render status: 401 unless current_spina_user.admin?
       end
 
+      def set_locale
+        @locale = params[:locale] || I18n.default_locale
+      end
+
     end
   end
 end

--- a/app/controllers/spina/admin/navigations_controller.rb
+++ b/app/controllers/spina/admin/navigations_controller.rb
@@ -4,6 +4,7 @@ module Spina
       layout 'spina/admin/pages'
 
       before_action :set_breadcrumb, except: [:show]
+      before_action :set_locale
 
       def show
         @navigation = Navigation.find(params[:id])
@@ -18,6 +19,7 @@ module Spina
       end
 
       def update
+        I18n.locale = params[:locale] || I18n.default_locale
         @navigation = Navigation.find(params[:id])
         if @navigation.update_attributes(navigation_params)
           redirect_to spina.admin_navigation_path(@navigation)
@@ -54,7 +56,7 @@ module Spina
         end
 
         def navigation_params
-          params.require(:navigation).permit(:auto_add_pages, page_ids: [])
+          params.require(:navigation).permit(:label, :auto_add_pages, page_ids: [])
         end
     end
   end

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -77,10 +77,6 @@ module Spina
 
       private
 
-      def set_locale
-        @locale = params[:locale] || I18n.default_locale
-      end
-
       def add_index_breadcrumb
         if @page.resource.present?
           add_breadcrumb @page.resource.label, spina.admin_resource_path(@page.resource)

--- a/app/models/spina/navigation.rb
+++ b/app/models/spina/navigation.rb
@@ -1,5 +1,7 @@
 module Spina
   class Navigation < ApplicationRecord
+    extend Mobility
+
     has_many :navigation_items, dependent: :destroy
     has_many :pages, through: :navigation_items
 
@@ -7,6 +9,8 @@ module Spina
 
     validates :name, :label, presence: true
     validates :name, uniqueness: true
+
+    translates :label
 
     def cache_key
       super + "_" + Mobility.locale.to_s

--- a/app/views/spina/admin/navigations/edit.html.haml
+++ b/app/views/spina/admin/navigations/edit.html.haml
@@ -1,10 +1,12 @@
 = form_for [:admin, @navigation] do |f|
   = hidden_field_tag 'navigation[page_ids][]', nil
+  = hidden_field_tag :locale, @locale
 
   %header#header
     #header_actions
       = button_tag t('spina.save'), class: 'button button-primary'
     .breadcrumbs= render_breadcrumbs separator: '<div class="divider"></div>'
+    = render partial: 'spina/admin/shared/locale_navigation', locals: {locale: @locale}
   
 
   .well
@@ -14,6 +16,11 @@
 
   .well
     .horizontal-form
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Account.human_attribute_name(:label)
+        .horizontal-form-content
+          = f.text_field :label, placeholder: Spina::Account.human_attribute_name(:label)
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Navigation.human_attribute_name :auto_add_pages

--- a/app/views/spina/admin/pages/_form.html.haml
+++ b/app/views/spina/admin/pages/_form.html.haml
@@ -12,16 +12,7 @@
   %header#header
     .breadcrumbs= render_breadcrumbs separator: '<div class="divider"></div>'
     - unless @page.new_record?
-      - if Spina.config.locales.size > 1
-        %div{style: 'display: inline-block; margin-left: 12px; position: absolute', data: {dropdown: true}}
-          = link_to '#', class: 'button button-link button-round button-small', data: {trigger: 'dropdown', target: '#locales'} do
-            = icon('comment')
-            = @locale.upcase
-
-          %ul#locales
-            - Spina.config.locales.each do |locale|
-              %li
-                = link_to t("languages.#{locale}"), "?locale=#{locale}", style: ('font-weight: 600' if @locale.to_s == locale.to_s)
+      = render partial: 'spina/admin/shared/locale_navigation', locals: {locale: @locale}
 
     #header_actions
       %button.button.button-primary{type: 'submit', style: 'margin-right: 0', data: {disable_with: t('spina.pages.saving')}}

--- a/app/views/spina/admin/shared/_locale_navigation.html.haml
+++ b/app/views/spina/admin/shared/_locale_navigation.html.haml
@@ -1,0 +1,10 @@
+- if Spina.config.locales.size > 1
+  %div{style: 'display: inline-block; margin-left: 12px; position: absolute', data: {dropdown: true}}
+    = link_to '#', class: 'button button-link button-round button-small', data: {trigger: 'dropdown', target: '#locales'} do
+      = icon('comment')
+      = locale.upcase
+
+    %ul#locales
+      - Spina.config.locales.each do |locale|
+        %li
+          = link_to t("languages.#{locale}"), "?locale=#{locale}", style: ('font-weight: 600' if locale.to_s == locale.to_s)

--- a/db/migrate/20180429120513_create_navigation_label_translations_for_mobility_table_backend.rb
+++ b/db/migrate/20180429120513_create_navigation_label_translations_for_mobility_table_backend.rb
@@ -1,0 +1,19 @@
+class CreateNavigationLabelTranslationsForMobilityTableBackend < ActiveRecord::Migration[5.1]
+  def change
+    create_table :spina_navigation_translations do |t|
+
+      # Translated attribute(s)
+      t.string :label
+
+      t.string  :locale, null: false
+      t.integer :spina_navigation_id, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :spina_navigation_translations, :spina_navigation_id, name: :index_spina_navigation_translations_on_spina_navigation_id
+    add_index :spina_navigation_translations, :locale, name: :index_spina_navigation_translations_on_locale
+    add_index :spina_navigation_translations, [:spina_navigation_id, :locale], name: :index_1177c363a7dedc0f63a4c192c3449fe4ea43b8ac, unique: true
+
+  end
+end


### PR DESCRIPTION
Added navigation group translations. This will allow users to set different label for each locale in navigations groups. 
This is useful if you have many navigations in your site (footer navigations groups, example: http://take.ms/jRfTq)

After updating you have to run 
```
rails spina:install:migrations
rails db:migrate
```

After successful installation there will be similar to pages edit switch with option to switch locale and enter label for each locale (http://take.ms/urijT).

Hope you find this useful.
