### PR TITLE
Fallback to generated fragment when page title cannot be parameterized

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -110,10 +110,17 @@ module Spina
 
       def generate_materialized_path
         if root?
-          name == 'homepage' ? '' : "#{url_title}"
+          name == 'homepage' ? '' : "#{path_fragment}"
         else
-          ancestors.collect(&:url_title).append(url_title).join('/')
+          ancestors.collect(&:url_title).append(path_fragment).join('/')
         end
+      end
+
+      def path_fragment
+        # We only invoke this when the title is set
+        return if title.nil?
+        return url_title if url_title.present?
+        title.gsub(" ", "-")
       end
 
   end

--- a/test/unit/spina/page_test.rb
+++ b/test/unit/spina/page_test.rb
@@ -2,8 +2,14 @@ require 'test_helper'
 
 module Spina
   class PageTest < ActiveSupport::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
+    test "#set_materialized_path assigns the parameterized page title" do
+      page = FactoryGirl.create :page, name: "new page", title: "My Great Page Title!"
+      assert_equal "/my-great-page-title", page.materialized_path
+    end
+
+    test "set_materialized_path assigns a generated path fragment when parameterized page title is blank" do
+      page = FactoryGirl.create :page, name: "new page", title: "我伟大的页面标题 我伟大的页面标题 我"
+      assert_equal "/我伟大的页面标题-我伟大的页面标题-我", page.materialized_path
+    end
   end
 end


### PR DESCRIPTION
Ran into an issue with chinese characters. Parameterize returns "" on these strings.  I've added a fallback for when parameterize returns an empty string. 

```
[1] pry(#<Spina::PageTest>)> "我伟大的页面标题".parameterize
=> ""
```