### PR TITLE
Menu presenter

### DIFF
--- a/app/models/spina/navigation_item.rb
+++ b/app/models/spina/navigation_item.rb
@@ -5,6 +5,7 @@ module Spina
 
     has_ancestry orphan_strategy: :adopt
 
+    scope :regular_pages, -> { joins(:page).where(spina_pages: {resource_id: nil}) }
     scope :sorted, -> { order('spina_navigation_items.position') }
     scope :live, -> { joins(:page).where(spina_pages: {draft: false, active: true}) }
     scope :in_menu, -> { joins(:page).where(spina_pages: {show_in_menu: true}) }
@@ -12,6 +13,6 @@ module Spina
 
     validates :page, uniqueness: {scope: :navigation}
 
-    delegate :menu_title, :materialized_path, to: :page
+    delegate :menu_title, :materialized_path, :draft?, to: :page
   end
 end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -46,6 +46,10 @@ module Spina
       name
     end
 
+    def page_id
+      id
+    end
+
     def url_title
       title.try(:parameterize)
     end

--- a/app/presenters/spina/menu_presenter.rb
+++ b/app/presenters/spina/menu_presenter.rb
@@ -1,0 +1,74 @@
+module Spina
+  class MenuPresenter
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::UrlHelper
+    include ActiveSupport::Configurable
+
+    attr_accessor :collection, :output_buffer
+
+    # Configuration
+    config_accessor :menu_tag, :menu_css,
+                    :list_tag, :list_css, 
+                    :list_item_tag, :list_item_css, 
+                    :link_tag_css,
+                    :include_drafts,
+                    :depth # root nodes are at depth 0
+
+    # Default configuration
+    self.menu_tag = :nav
+    self.list_tag = :ul
+    self.list_item_tag = :li
+    self.include_drafts = false
+
+    def initialize(collection)
+      @collection = collection
+    end
+
+    def to_html
+      render_menu(roots)
+    end
+
+    private
+
+      def roots
+        return collection.navigation_items.roots if collection.is_a?(Navigation)
+        collection.roots
+      end
+
+      def render_menu(collection)
+        content_tag(menu_tag, class: menu_css) do
+          render_items(scoped_collection(collection))
+        end
+      end
+
+      def render_items(collection)
+        content_tag(list_tag, class: list_css) do
+          collection.inject(ActiveSupport::SafeBuffer.new) do |buffer, item|
+            buffer << render_item(item)
+          end
+        end
+      end
+
+      def render_item(item)
+        children = scoped_collection(item.children)
+
+        content_tag(list_item_tag, class: list_item_css, data: {page_id: item.page_id, draft: (true if item.draft?) }) do
+          buffer = ActiveSupport::SafeBuffer.new
+          buffer << link_to(item.menu_title, item.materialized_path, class: link_tag_css)
+          buffer << render_items(children) if render_children?(item) && children.any?
+          buffer
+        end
+      end
+
+      def scoped_collection(collection)
+        scoped = collection.regular_pages.active.in_menu.sorted
+        include_drafts ? scoped : scoped.live
+      end
+
+      def render_children?(item)
+        return true unless depth
+        item.depth < depth
+      end
+
+  end
+end

--- a/lib/generators/spina/templates/app/views/default/shared/_navigation.html.haml
+++ b/lib/generators/spina/templates/app/views/default/shared/_navigation.html.haml
@@ -1,3 +1,2 @@
-.nav
-  - Spina::Page.live.all.each do |page|
-    .nav-item{class: ('active' if page == current_page)}= link_to page.menu_title, page.materialized_path
+- presenter = Spina::MenuPresenter.new(Spina::Page.all)
+= presenter.to_html

--- a/lib/generators/spina/templates/app/views/demo/pages/demo.html.haml
+++ b/lib/generators/spina/templates/app/views/demo/pages/demo.html.haml
@@ -8,18 +8,19 @@
 
 %h5 Image
 
-%p= image_tag content(:image).variant(resize: "200x100")
+- if has_content?(:image)
+  %p= image_tag content(:image).variant(resize: "200x100")
 
 %h5 Image collection
 
 %ul
-  - content(:image_collection).images.each do |image|
+  - content(:image_collection)&.images&.each do |image|
     %li= image_tag image.variant(resize: '100x100')
 
 %h5 Structure
 
 %ul
-  - content(:structure).structure_items.each do |item|
+  - content(:structure)&.structure_items&.each do |item|
     %li
       %h6 Title
       %p= item.content(:title)

--- a/lib/generators/spina/templates/app/views/demo/shared/_navigation.html.haml
+++ b/lib/generators/spina/templates/app/views/demo/shared/_navigation.html.haml
@@ -1,3 +1,2 @@
-.nav
-  - Spina::Page.live.all.each do |page|
-    .nav-item{class: ('active' if page == current_page)}= link_to page.menu_title, page.materialized_path
+- presenter = Spina::MenuPresenter.new(Spina::Page.all)
+= presenter.to_html

--- a/test/dummy/app/views/default/shared/_navigation.html.haml
+++ b/test/dummy/app/views/default/shared/_navigation.html.haml
@@ -1,3 +1,2 @@
-.nav
-  - Spina::Page.live.all.each do |page|
-    .nav-item{class: ('active' if page == current_page)}= link_to page.menu_title, page.materialized_path
+- presenter = Spina::MenuPresenter.new(Spina::Page.all)
+= presenter.to_html

--- a/test/dummy/app/views/demo/pages/demo.html.haml
+++ b/test/dummy/app/views/demo/pages/demo.html.haml
@@ -8,23 +8,21 @@
 
 %h5 Image
 
-%p
-  = image_tag main_app.url_for(content(:image).variant(resize: "200x200")), width: 100
+- if has_content?(:image)
+  %p= image_tag content(:image).variant(resize: "200x200")
 
 %h5 Image collection
 
 %ul
-  - if has_content?(:image_collection)
-    - content(:image_collection).images.each do |image|
-      %li= image_tag main_app.url_for(image.variant(resize: '200x200')), width: 100
+  - content(:image_collection)&.images&.each do |image|
+    %li= image_tag image.variant(resize: '100x100')
 
 %h5 Structure
 
 %ul
-  - if has_content?(:structure)
-    - content(:structure).structure_items.each do |item|
-      %li
-        %h6 Title
-        %p= item.content(:title)
-        %h6 Description
-        != item.content(:description)
+  - content(:structure)&.structure_items&.each do |item|
+    %li
+      %h6 Title
+      %p= item.content(:title)
+      %h6 Description
+      != item.content(:description)

--- a/test/dummy/app/views/demo/shared/_navigation.html.haml
+++ b/test/dummy/app/views/demo/shared/_navigation.html.haml
@@ -1,3 +1,2 @@
-.nav
-  - Spina::Page.live.all.each do |page|
-    .nav-item{class: ('active' if page == current_page)}= link_to page.menu_title, page.materialized_path
+- presenter = Spina::MenuPresenter.new(Spina::Page.all)
+= presenter.to_html


### PR DESCRIPTION
Use a menu presenter to generate HTML for navigation:

## Using Spina::Page
```ruby
presenter = Spina::MenuPresenter.new(Spina::Page.all)
presenter.to_html
```

## Using Spina::Navigation
You can also use `Spina::Navigation`
```ruby
presenter = Spina::MenuPresenter.new(Spina::Navigation.find_by(name: "main"))
presenter.to_html
```

## Config accessors

```ruby
:menu_tag # default: nav
:menu_css
:list_tag # default: ul
:list_css
:list_item_tag # default: li
:list_item_css 
:link_tag_css 
:include_drafts # default: false
:depth # root level is 0
```