### PR TITLE
Local false, bug fix for modal form

### DIFF
--- a/app/views/spina/admin/media_picker/_modal.html.haml
+++ b/app/views/spina/admin/media_picker/_modal.html.haml
@@ -4,7 +4,7 @@
       .item.item-small.item-uploader.new-image-form
         = render partial: 'spina/admin/images/form'
 
-      = form_with url: admin_media_picker_path, class: 'gallery-prepend-image' do
+      = form_with url: admin_media_picker_path, class: 'gallery-prepend-image', local: false do
         = hidden_field_tag :hidden_field_id, params[:hidden_field_id]
         = hidden_field_tag :trix_editor_id, params[:trix_editor_id]
         = check_box_tag :multiple, true, defined?(multiple) && multiple, style: 'display: none'


### PR DESCRIPTION
Hey! Thanks for all of the hard work on Spina. We ran into a bug with Spina (#385) from the mater branch with rails 5.2. So I hopped in the code and forced the SJR to happen by adding `local: false` to the modal.

Not sure if this is an issue or not for anyone else, but it's here if you want to merge it.