### PR TITLE
Revert "Fallback to generated fragment when page title cannot be parameterized"

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -114,17 +114,10 @@ module Spina
 
       def generate_materialized_path
         if root?
-          name == 'homepage' ? '' : "#{path_fragment}"
+          name == 'homepage' ? '' : "#{url_title}"
         else
-          ancestors.collect(&:url_title).append(path_fragment).join('/')
+          ancestors.collect(&:url_title).append(url_title).join('/')
         end
-      end
-
-      def path_fragment
-        # We only invoke this when the title is set
-        return if title.nil?
-        return url_title if url_title.present?
-        title.gsub(" ", "-")
       end
 
   end

--- a/test/unit/spina/page_test.rb
+++ b/test/unit/spina/page_test.rb
@@ -2,14 +2,8 @@ require 'test_helper'
 
 module Spina
   class PageTest < ActiveSupport::TestCase
-    test "#set_materialized_path assigns the parameterized page title" do
-      page = FactoryGirl.create :page, name: "new page", title: "My Great Page Title!"
-      assert_equal "/my-great-page-title", page.materialized_path
-    end
-
-    test "set_materialized_path assigns a generated path fragment when parameterized page title is blank" do
-      page = FactoryGirl.create :page, name: "new page", title: "我伟大的页面标题 我伟大的页面标题 我"
-      assert_equal "/我伟大的页面标题-我伟大的页面标题-我", page.materialized_path
-    end
+    # test "the truth" do
+    #   assert true
+    # end
   end
 end


### PR DESCRIPTION
This reverts commit c55615225498fef3b4cdeb28e8733835d89fd528.

We need to update `FactoryGirl` to `FactoryBot` and fix the failing page spec.