### PR TITLE
Translations including fallbacks

### DIFF
--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -42,18 +42,17 @@ module Spina
         render layout: 'spina/admin/admin'
       end
 
-      def update
-        I18n.locale = params[:locale] || I18n.default_locale        
+      def update 
         respond_to do |format|
+          Mobility.locale = @locale
           if @page.update_attributes(page_params)
-            add_breadcrumb @page.title
             @page.touch
-            I18n.locale = I18n.default_locale
             format.html { redirect_to spina.edit_admin_page_url(@page, params: {locale: @locale}), flash: {success: t('spina.pages.saved')} }
             format.js
           else
             format.html do
               @page_parts = @page.view_template_page_parts(current_theme).map { |part| @page.part(part) }
+              Mobility.locale = I18n.default_locale
               render :edit, layout: 'spina/admin/admin'
             end
           end

--- a/app/models/spina/line.rb
+++ b/app/models/spina/line.rb
@@ -1,7 +1,7 @@
 module Spina
   class Line < ApplicationRecord
     extend Mobility
-    translates :content
+    translates :content, fallbacks: true
 
     has_many :page_parts, as: :page_partable
     has_many :layout_parts, as: :layout_partable

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -39,7 +39,8 @@ module Spina
     before_validation :set_materialized_path
     validates :title, presence: true
 
-    translates :title, :description, :materialized_path
+    translates :title, fallbacks: true
+    translates :description, :materialized_path
     translates :menu_title, :seo_title, default: -> { title }
 
     def to_s
@@ -77,7 +78,7 @@ module Spina
     def set_materialized_path
       self.old_path = materialized_path
       self.materialized_path = localized_materialized_path
-      self.materialized_path += "-#{self.class.i18n.where(materialized_path: materialized_path).count}" if self.class.i18n.where(materialized_path: materialized_path).where.not(id: id).count > 0
+      self.materialized_path = localized_materialized_path + "-#{self.class.i18n.where(materialized_path: materialized_path).count}" if self.class.i18n.where(materialized_path: materialized_path).where.not(id: id).count > 0
       materialized_path
     end
 

--- a/app/models/spina/text.rb
+++ b/app/models/spina/text.rb
@@ -1,7 +1,7 @@
 module Spina
   class Text < ApplicationRecord
     extend Mobility
-    translates :content
+    translates :content, fallbacks: true
     
     has_many :page_parts, as: :page_partable
     has_many :layout_parts, as: :layout_partable

--- a/app/views/spina/admin/pages/_form.html.haml
+++ b/app/views/spina/admin/pages/_form.html.haml
@@ -24,7 +24,7 @@
               %ul#locales
                 - Spina.config.locales.each do |locale|
                   %li
-                    = link_to t("languages.#{locale}"), "?locale=#{locale}", style: ('font-weight: 600' if @locale.to_s == locale.to_s)
+                    = link_to t("languages.#{locale}"), "?locale=#{locale}", style: ('font-weight: 600' if @locale.to_s == locale.to_s).to_s
 
         = link_to @page.materialized_path, target: :blank, class: 'button button-hollow button-small', style: 'margin-left: 0' do
           %i.icon.icon-export{style: 'margin: 0'}

--- a/app/views/spina/admin/partables/lines/_form.html.haml
+++ b/app/views/spina/admin/partables/lines/_form.html.haml
@@ -2,4 +2,4 @@
   = f.object.title
 .horizontal-form-content
   = f.fields_for :partable, f.object.partable do |ff|
-    = ff.text_field :content
+    = ff.text_field :content, value: ff.object.content(fallback: false, default: nil)

--- a/app/views/spina/admin/partables/texts/_form.html.haml
+++ b/app/views/spina/admin/partables/texts/_form.html.haml
@@ -2,4 +2,7 @@
   = f.object.title
 .horizontal-form-content
   = f.fields_for :partable, f.object.partable do |ff|
-    = render 'spina/admin/shared/rich_text_field', f: ff, field: :content
+    - object_id = (ff.object.persisted? ? ff.object.object_id : "new_association_#{ff.object.object_id}").to_s + "_content"
+    = ff.hidden_field :content, id: "#{object_id}_input", value: ff.object.content(fallback: false, default: nil)
+    %trix-editor.text-input.trix-content{ input: "#{object_id}_input" }
+

--- a/lib/tasks/spina_tasks.rake
+++ b/lib/tasks/spina_tasks.rake
@@ -8,8 +8,14 @@ namespace :spina do
   desc "Update translations after adding locales"
   task update_translations: :environment do
     Spina.locales.each do |locale|
-      I18n.locale = locale
-      Spina::Page.find_each(&:save!)
+      Mobility.with_locale(locale) do
+
+        Spina::Page.all.order(:id).each do |page|
+          page.title = page.title(fallback: Mobility.new_fallbacks[locale])
+          page.save
+        end
+
+      end
     end
   end
 

--- a/test/functional/spina/pages_controller_test.rb
+++ b/test/functional/spina/pages_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 module Spina
   class PagesControllerTest < ActionController::TestCase
     setup do
+      I18n.locale = :en
       @routes = Engine.routes
       @current_account = FactoryBot.create :account
     end


### PR DESCRIPTION
This PR includes a couple of changes to better handle creating pages with multiple translations. Content like `Spina::Line` and `Spina::Text` will have fallbacks so that you can rely on something to be there in other locales. The forms themselves when editing pages do not show fallback values so you don't accidentally override a nil value.

Todo: In my own app I added an `after_create` callback to save all translations for a page after creation so that all records are created successfully. Ideally this should happen in a background job.