### PR TITLE
Update partials for Turbolinks 5

### DIFF
--- a/app/views/spina/shared/_admin_bar.html.haml
+++ b/app/views/spina/shared/_admin_bar.html.haml
@@ -1,4 +1,4 @@
 - if current_spina_user.present?
   #admin_bar
-    = link_to t('spina.edit_website'), spina.admin_root_url, data: {icon: 'q', :"no-turbolink" => true}, class: 'button button-hollow button-round button-small'
+    = link_to t('spina.edit_website'), spina.admin_root_url, data: {icon: 'q', turbolinks: false}, class: 'button button-hollow button-round button-small'
     = link_to t('spina.logout'), spina.admin_logout_path, data: {icon: 'h'}, class: 'button button-hollow button-round button-small'

--- a/app/views/spina/shared/_social.html.haml
+++ b/app/views/spina/shared/_social.html.haml
@@ -1,5 +1,5 @@
 - if current_account.facebook.present?
-  = link_to "", current_account.facebook, class: 'facebook-button', data: {:"no-turbolink" => true}
+  = link_to "", current_account.facebook, class: 'facebook-button', data: {turbolinks: false}
 
 - if current_account.twitter.present?
-  = link_to "", current_account.twitter, class: 'twitter-button', data: {:"no-turbolink" => true}
+  = link_to "", current_account.twitter, class: 'twitter-button', data: {turbolinks: false}


### PR DESCRIPTION
### Context

The `_admin_bar` and `_social` partials still use `data-no-turbolinks="true"` to disable Turbolinks, but Turbolinks now uses `data-turbolinks="false"`.

### Changes proposed in this pull request

This PR changes remaining uses of `:"no-turbolink" => true` to `turbolinks: false`