### PR TITLE
Fix action-bar overlap on ImageCollection

### DIFF
--- a/app/assets/stylesheets/spina/_gallery.sass
+++ b/app/assets/stylesheets/spina/_gallery.sass
@@ -190,14 +190,13 @@
     align-items: center
     background: #fff
     border-top: 1px solid #e5e5e5
-    clear: both
     display: flex
     justify-content: flex-end
     margin-top: 12px
     padding: 12px 12px 0
 
     .button
-      margin: 0
+      margin: 0 0 0 4px
 
 // Customfile
 

--- a/app/assets/stylesheets/spina/_gallery.sass
+++ b/app/assets/stylesheets/spina/_gallery.sass
@@ -187,15 +187,17 @@
       opacity: .7
 
   .gallery-select-action-bar
+    align-items: center
     background: #fff
     border-top: 1px solid #e5e5e5
-    bottom: 0px
     clear: both
-    margin: 0 -12px
-    padding: 12px
-    position: absolute
-    width: 100%
-    z-index: 3
+    display: flex
+    justify-content: flex-end
+    margin-top: 12px
+    padding: 12px 12px 0
+
+    .button
+      margin: 0
 
 // Customfile
 

--- a/app/views/spina/admin/media_picker/_modal.html.haml
+++ b/app/views/spina/admin/media_picker/_modal.html.haml
@@ -19,11 +19,10 @@
 
         - if defined?(multiple) && multiple
           .gallery-select-action-bar
-            .pull-right
-              = link_to t('spina.cancel'), "#", class: 'button button-link', data: {dismiss: 'modal'}
-              = button_tag type: 'submit', class: 'button button-primary button-large', style: 'margin-bottom: 0px' do
-                = icon('plus')
-                = t('spina.images.choose_images')
-                %span.gallery-select-counter
-                  - if params[:selected_ids].try(:any?)
-                    (#{ params[:selected_ids].count })
+            = link_to t('spina.cancel'), "#", class: 'button button-link', data: {dismiss: 'modal'}
+            = button_tag type: 'submit', class: 'button button-primary button-large', style: 'margin-bottom: 0px' do
+              = icon('plus')
+              = t('spina.images.choose_images')
+              %span.gallery-select-counter
+                - if params[:selected_ids].try(:any?)
+                  (#{ params[:selected_ids].count })


### PR DESCRIPTION
### Issue 😭
<img width="1163" alt="Screenshot 2019-07-02 at 22 50 15" src="https://user-images.githubusercontent.com/50486078/60549165-f9139a00-9d1b-11e9-8284-83e7c8ffb2dc.png">

### Fix 😃
<img width="1169" alt="Screenshot 2019-07-02 at 22 49 36" src="https://user-images.githubusercontent.com/50486078/60549083-b94cb280-9d1b-11e9-874c-296c5ab6f5d0.png">

### Changes

- Removal of `position: absolute` in the CSS to be replaced with `flexbox` usage
- Removal of the `.float-right` class used in the modal HTML

### Guidance

Small change so shouldn't be any breaks. The `.float-right` style is replaced with `flexbox` CSS
