### PR TITLE
fix image gallery view

### DIFF
--- a/app/assets/stylesheets/spina/_gallery.sass
+++ b/app/assets/stylesheets/spina/_gallery.sass
@@ -10,6 +10,7 @@
 
 .gallery-select-container
   display: flex
+  width: 100%
 
   .gallery-select
     flex: 1
@@ -32,8 +33,7 @@
 .gallery-select-action-bar
   align-items: center
   display: flex
-  justify-content: flex-end
-  
+
   .button
     margin-bottom: 0
 
@@ -151,7 +151,7 @@
   display: block
 
 .gallery-select
-  margin: -8px
+  margin: 0
 
   &.gallery-select-multiple
     padding-bottom: 70px


### PR DESCRIPTION
### Context

Fix the new image gallery view.

### From this 😢
![Screenshot 2019-09-04 at 14 42 21](https://user-images.githubusercontent.com/50486078/64260129-3cf46c80-cf22-11e9-976c-2d4bc649d057.png)

### To this 😄
![Screenshot 2019-09-04 at 14 39 48](https://user-images.githubusercontent.com/50486078/64260087-2817d900-cf22-11e9-9ef2-277d0a1a9131.png)

### Changes

- Push the 'Cancel / Save' section to the right
- Remove the `flex-end` on the wrapper for the 'Cancel / Save' buttons. Didn't look right with `flex-end`
- Remove the negative `margin` on the gallery container. Assume this was to cut down on white space created by the `margin` on the gallery items, but it was hiding parts of the image.
