### PR TITLE
Image management

### DIFF
--- a/app/assets/javascripts/spina/admin/media_gallery.coffee
+++ b/app/assets/javascripts/spina/admin/media_gallery.coffee
@@ -29,7 +29,7 @@ ready = ->
   $('.media-folder').droppable(
     drop: (event, ui) ->
       url = $(this).attr('data-add-to-media-folder-url')
-      image_id = $(ui.draggable).find('input[type="radio"]').val()
+      image_id = $(ui.draggable).attr('data-image-id')
 
       $.ajax
         url: url,

--- a/app/assets/stylesheets/spina/_gallery.sass
+++ b/app/assets/stylesheets/spina/_gallery.sass
@@ -113,7 +113,7 @@
         line-height: 15px
         text-align: left
         transition: all 0.2s ease
-        transform: translateY(-100%)
+        opacity: 0
         padding: 10px
         position: absolute
         word-break: break-word
@@ -131,7 +131,7 @@
           transform: translateY(0%)
 
         .photo-name
-          transform: translateY(0%)
+          opacity: 1
 
     &.dropping:not(.media-folder)
       transform: scale(0.8)

--- a/app/controllers/spina/admin/images_controller.rb
+++ b/app/controllers/spina/admin/images_controller.rb
@@ -18,7 +18,7 @@ module Spina
       def create
         @images = params[:image][:files].map do |file|
           # Create the image and attach the file
-          image = Image.create
+          image = Image.create(media_folder_id: params[:media_library])
           image.file.attach(file)
 
           # Was it not an image after all? DESTROY IT

--- a/app/controllers/spina/admin/media_picker_controller.rb
+++ b/app/controllers/spina/admin/media_picker_controller.rb
@@ -1,9 +1,14 @@
 module Spina
   module Admin
     class MediaPickerController < AdminController
+      before_action :set_media_folders
 
       def show
-        @images = Image.page(params[:page])
+        if @media_folder.present?
+          @images = @media_folder.images.page(params[:page])
+        else
+          @images = Image.where(media_folder_id: nil).page(params[:page])
+        end
 
         if params[:selected_ids].present?
           ids = params[:selected_ids].map(&:to_i).join(', ')
@@ -22,6 +27,13 @@ module Spina
           @image = Image.find(params[:image_id])
         end
       end
+
+      private
+
+        def set_media_folders
+          @media_folders = MediaFolder.order(:name)
+          @media_folder = MediaFolder.find(params[:media_folder_id]) if params[:media_folder_id].present?
+        end
 
     end
   end

--- a/app/views/spina/admin/images/_form.html.haml
+++ b/app/views/spina/admin/images/_form.html.haml
@@ -1,5 +1,5 @@
 = form_for [:admin, Spina::Image.new], id: 'new_image', class: 'new_image', data: {remote: true} do |f|
   = f.submit style: 'display: none'
-  = hidden_field_tag :media_library, value: true
+  = hidden_field_tag :media_library, @media_folder.try(:id)
   = f.label :file, t('spina.images.upload')
   = f.file_field :files, multiple: true, accept: "image/*", data: {direct_upload_url: main_app.rails_direct_uploads_url, customfileinput: true}

--- a/app/views/spina/admin/media_folders/show.html.haml
+++ b/app/views/spina/admin/media_folders/show.html.haml
@@ -6,7 +6,7 @@
     .item
       = form_with model: [:admin, Spina::Image.new], id: 'new_image', class: 'new_image' do |f|
         = f.submit style: 'display: none'
-        = hidden_field_tag :media_library, value: @media_folder.id
+        = hidden_field_tag :media_library, @media_folder.id
         = f.label :file, t('spina.images.upload')
         = f.file_field :files, multiple: true, data: {direct_upload_url: main_app.rails_direct_uploads_url, customfileinput: true}
 

--- a/app/views/spina/admin/media_picker/_modal.html.haml
+++ b/app/views/spina/admin/media_picker/_modal.html.haml
@@ -5,6 +5,19 @@
         .item.item-small.item-uploader.new-image-form
           = render partial: 'spina/admin/images/form'
 
+        - if @media_folder.present?
+
+        - else
+          - @media_folders.each do |media_folder|
+            = link_to spina.admin_media_picker_path({media_folder_id: media_folder.id}.merge(request.query_parameters)), class: 'item media-folder', data: {remote: true} do
+              .media-folder-thumbnail{data: {badge: media_folder.images.count}}
+                - if media_folder.images.any?
+                  = image_tag variant(media_folder.images.last.file, resize: '144x144^', crop: "144x144+0+0")
+                - else
+                  = image_tag 'spina/media_folder_placeholder.svg'
+                .media-folder-shadow
+              .media-folder-name= media_folder.name
+
         .infinite-scroll
           = render partial: 'spina/admin/images/image', collection: @images
 

--- a/app/views/spina/admin/media_picker/_modal.html.haml
+++ b/app/views/spina/admin/media_picker/_modal.html.haml
@@ -6,7 +6,11 @@
           = render partial: 'spina/admin/images/form'
 
         - if @media_folder.present?
-
+          = link_to spina.admin_media_picker_path(request.query_parameters.merge(media_folder_id: nil)), class: 'item media-folder', data: {remote: true} do
+            .media-folder-thumbnail
+              = image_tag 'spina/media_folder_placeholder.svg'
+              .media-folder-shadow
+            .media-folder-name=t "spina.images.back"
         - else
           - @media_folders.each do |media_folder|
             = link_to spina.admin_media_picker_path({media_folder_id: media_folder.id}.merge(request.query_parameters)), class: 'item media-folder', data: {remote: true} do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,6 +102,7 @@ en:
       choose_images: Choose images
       choose_image: Choose image
       remove_image: Remove image
+      back: Back
 
     wysiwyg:
       paragraph: Paragraph

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -48,6 +48,7 @@ nl:
       upload: kies een bestand
       choose_image: Kies afbeelding
       remove_image: Verwijder afbeelding
+      back: Terug
 
     forgot_password:
       new: Wachtwoord vergeten


### PR DESCRIPTION
- Fixed a bug where images couldn't be added to media folders
- You can now upload images directly to a media folder
- Media folders are now also included in the media picker modal (so there's an actual use to organizing media in folders, haha!)

<img width="644" alt="Schermafbeelding 2019-10-28 om 13 12 58" src="https://user-images.githubusercontent.com/423116/67677573-ad4cc680-f984-11e9-8423-eede1fcddffa.png">

