### PR TITLE
Lower Rails version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       mobility (>= 0.8.9)
       pg
       rack-rewrite (>= 1.5.0)
-      rails (>= 6.0)
+      rails (>= 5.2)
       sass-rails
       turbolinks (~> 5)
 

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,vendor}/**/*'] + ['Rakefile', 'README.md']
   # s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '>= 6.0'
+  s.add_dependency 'rails', '>= 5.2'
   s.add_dependency 'pg'
   s.add_dependency 'bcrypt'
   s.add_dependency 'haml-rails'


### PR DESCRIPTION
It's not necessary to require Rails 6.0, so let's ease up on that requirement!