### PR TITLE
Missing spanish translation for all_pages

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,6 +42,7 @@ es:
     website:
       title: Tu sitio
       pages: Páginas
+      all_pages: Todas las páginas
       pages_description: "Todas las páginas de tu sitio"
       media_library: Biblioteca de medios
       media_library_description: "Aquí encontrarás todas tus imágenes y documentos"


### PR DESCRIPTION
### Context
Missing spanish translation on `admin/pages` #487
