### PR TITLE
Add rails application load_tasks to be improve compatibility with customized rails framework

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require_relative 'config/application'
+
 begin
   require 'bundler/setup'
 rescue LoadError
@@ -30,3 +32,5 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task :default => :test
+
+Rails.application.load_tasks


### PR DESCRIPTION
### Context

We are trying to install `rspec` to secure our changes on the application that we are using the _Spina_ and we can't access the rails tasks to install and run this specs.

### Changes proposed in this pull request

Add Rails `load_tasks` to the default Rakefile load.

