### PR TITLE
Use Mobility instead of I18n

### DIFF
--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -42,7 +42,7 @@ module Spina
         render layout: 'spina/admin/admin'
       end
 
-      def update 
+      def update
         respond_to do |format|
           Mobility.locale = @locale
           if @page.update(page_params)

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -106,10 +106,10 @@ module Spina
       end
 
       def localized_materialized_path
-        if I18n.locale == I18n.default_locale
+        if Mobility.locale == I18n.default_locale
           generate_materialized_path.prepend('/')
         else
-          generate_materialized_path.prepend("/#{I18n.locale}/").gsub(/\/\z/, "")
+          generate_materialized_path.prepend("/#{Mobility.locale}/").gsub(/\/\z/, "")
         end
       end
 


### PR DESCRIPTION
### Context
See #519 

### Changes proposed in this pull request
Use Mobility on `localized_materialized_path`

### Guidance to review
I believe this broke when 451541fff35ff34811682e60df2272ca7c13163f got merged, I did not performed a `git bisect` but changes in the said commit lead me in this train of thought