### PR TITLE
Structure returns structure_items by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,44 @@
 # Spina CMS Changelog
 
-## 1.1
+## Unreleased
 
-### 1.1.3 (December 25, 2019)
+### Changed
+* Structures now return `structure_items` directly instead of `self`
+* Bump gem dependencies
 
-* Added missing icons to Trix editor
+## [1.1.3] - December 25, 2019
 
-### 1.1.2 (December 20, 2019)
+### Added
+* Missing icons to Trix editor
 
-* Change Spina's admin font to Metropolis
+## [1.1.2] - December 20, 2019
+
+### Added
 * Add missing translations for Spanish
 * Add missing translations for Italian
+
+### Changed
+* Change Spina's admin font to Metropolis
 * Rename media folders
 * Cleaner Readme.md and guides
-* Removed Font Awesome dependency
 
-### 1.1.1 (November 11, 2019)
+### Removed
+* Font Awesome dependency
 
+## [1.1.1] - November 11, 2019
+
+### Changed
 * Dropped the requirement for Rails to >= 5.2.
 
-### 1.1.0 (November 3, 2019)
+## [1.1.0] - November 3, 2019
 
+### Added
+* Documentation
 * Support for Rails 6
 * Support for Sprockets 4
-* Better image management using media folders
-* Upgrade Trix
-* Added documentation
-* Bump gem dependencies
 * Add support for alt texts and links to images in Trix
+
+### Changed
+* Upgrade Trix
+* Bump gem dependencies
+* Better image management using media folders

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,21 @@
+# Upgrading Spina CMS
+This file lists all changes that you need to make in your Spina app to ensure a smooth upgrade.
+
+## [1.1.3] to Unreleased
+
+### Structures in views
+When calling `content` on a `Structure` page part Spina will now return the underlying items instead of the structure itself. That means you need to change all views using a structure. 
+
+Before:
+```ruby
+content(:a_structure).structure_items.sorted_by_structure.each do |item|
+  # ...
+end
+```
+
+After:
+```ruby
+content(:a_structure).each do |item|
+  # ...
+end
+```

--- a/app/models/spina/structure.rb
+++ b/app/models/spina/structure.rb
@@ -8,7 +8,7 @@ module Spina
     accepts_nested_attributes_for :structure_items, allow_destroy: true
 
     def content
-      self
+      structure_items.order(:position)
     end
   end
 end

--- a/lib/generators/spina/templates/app/views/demo/pages/demo.html.haml
+++ b/lib/generators/spina/templates/app/views/demo/pages/demo.html.haml
@@ -20,7 +20,7 @@
 %h5 Structure
 
 %ul
-  - content(:structure)&.structure_items&.each do |item|
+  - content(:structure)&.each do |item|
     %li
       %h6 Title
       %p= item.content(:title)

--- a/test/dummy/app/views/demo/pages/demo.html.haml
+++ b/test/dummy/app/views/demo/pages/demo.html.haml
@@ -20,7 +20,7 @@
 %h5 Structure
 
 %ul
-  - content(:structure)&.structure_items&.each do |item|
+  - content(:structure)&.each do |item|
     %li
       %h6 Title
       %p= item.content(:title)


### PR DESCRIPTION
### Changes proposed in this pull request
* Structures now return `structure_items` directly instead of `self`
* Added more structure to CHANGELOG.md
* Added UPGRADING.md

### Structures in views
When calling `content` on a `Structure` page part Spina will now return the underlying items instead of the structure itself. That means you need to change all views using a structure. 

Before:
```ruby
content(:a_structure).structure_items.sorted_by_structure.each do |item|
  # ...
end
```

After:
```ruby
content(:a_structure).each do |item|
  # ...
end
```