### PR TITLE
Allow SVGs to be displayed

### DIFF
--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -8,6 +8,14 @@ module Spina
       if image.attached? && image.variable?
         variant = image.variant(options)
         main_app.rails_blob_representation_path(variant.blob.signed_id, variant.variation.key, variant.blob.filename)
+      elsif image.image?
+        # Allows SVGs to be displayed as they are not variable. Requires:
+        # - https://github.com/Dreamersoul/administrate-field-active_storage/issues/36#issuecomment-608446819 to be applied
+        #
+        # Additionally, https://github.com/hopsoft/active_storage_svg_sanitizer/
+        # should be added if users are able to upload their own SVG content due to:
+        # https://github.com/rails/rails/issues/34665#issuecomment-445888009
+        main_app.url_for(image)
       else
         "https://placehold.it/100x100.png"
       end

--- a/docs/8_advanced.md
+++ b/docs/8_advanced.md
@@ -1,0 +1,1 @@
+# Advanced Spina

--- a/docs/advanced/0_svg_files.md
+++ b/docs/advanced/0_svg_files.md
@@ -1,0 +1,17 @@
+# SVG Files in Spina
+
+Files with the `imge/svg+xml` content type can be used as XSS vectors. As such, [Rails by default forces their `Content-Disposition` header to `attachment`](https://github.com/rails/rails/issues/34665#issuecomment-445888009). If you wish to use SVG images in `<img>` tags, you will need to remove the content type for the sanitizer.
+
+You can use the [following code](https://github.com/Dreamersoul/administrate-field-active_storage/issues/36#issuecomment-608446819) in an initializer to achieve this:
+
+```ruby
+# Warning: Make sure to sanitize SVGs if users gain the ability to upload themselves:
+# https://github.com/rails/rails/issues/34665#issuecomment-446601748
+Rails.application.config.active_storage.content_types_to_serve_as_binary.delete("image/svg+xml")
+```
+
+Additionally, and particularly if you intend to let users upload their own SVG content, add the [`active_storage_svg_sanitizer` gem](https://github.com/hopsoft/active_storage_svg_sanitizer/) to your `Gemfile`:
+
+```
+gem 'active_storage_svg_sanitizer'
+```


### PR DESCRIPTION
### Context

SVGs don't display in the media library or in image pickers as they are not variable. This patch fixes that.

### Changes proposed in this pull request

As ActiveStorage > 5.2.1 forces SVGs to be downloaded as attachments due to XSS risks (https://github.com/rails/rails/issues/34665#issuecomment-445888009) we need to tell users to remove `image/svg+xml` from the sanitiser. Example provided [here](https://github.com/Dreamersoul/administrate-field-active_storage/issues/36#issuecomment-608446819).

I've written this into the pull request, but it will probably need adding to the guides.

### Guidance to review

Upload an SVG to the media library. I'm working locally, so this was tested using local `disk` storage. Then add the initializer and restart.