### PR TITLE
Spina v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.1
 
+### 1.1.4 (May 8, 2020)
+
+* Allow SVGs to be displayed
+* Fixed bug with @extend in sass files
+* Improved translations
+
 ### 1.1.3 (December 25, 2019)
 
 * Added missing icons to Trix editor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina (1.1.3)
+    spina (1.1.4)
       ancestry
       bcrypt
       breadcrumbs_on_rails
@@ -217,7 +217,7 @@ GEM
     request_store (1.5.0)
       rack (>= 1.4)
     ruby-progressbar (1.10.1)
-    ruby_parser (3.14.1)
+    ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -229,7 +229,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sexp_processor (4.13.0)
+    sexp_processor (4.14.1)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
# Changes in this release

* Allow SVGs to be displayed
* Fixed bug with @extend in sass files
* Improved translations