### PR TITLE
Remove the option to have a parent page for resources - Fixes #565

### DIFF
--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -13,7 +13,7 @@ module Spina
 
       def new
         @resource = Resource.find_by(id: params[:resource_id])
-        @page = Page.new(resource: @resource, parent: Page.find_by(id: params[:parent_id]) || @resource&.parent_page)
+        @page = Page.new(resource: @resource, parent: Page.find_by(id: params[:parent_id]))
         add_index_breadcrumb
         if current_theme.new_page_templates.any? { |template| template[0] == params[:view_template] }
           @page.view_template = params[:view_template]

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -28,6 +28,9 @@ module Spina
     scope :live, -> { active.where(draft: false) }
     scope :in_menu, -> { where(show_in_menu: true) }
 
+    # Copy resource from parent
+    before_save :set_resource_from_parent, if: -> { parent.present? }
+
     # Save children to update all materialized_paths
     after_save :save_children
     after_save :touch_navigations
@@ -96,6 +99,10 @@ module Spina
     end
 
     private
+
+      def set_resource_from_parent
+        self.resource_id = parent.resource_id 
+      end
 
       def touch_navigations
         navigations.update_all(updated_at: Time.zone.now)

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -2,10 +2,6 @@ module Spina
   class Resource < ApplicationRecord
     has_many :pages, dependent: :restrict_with_exception
 
-    # belongs_to :parent_page, class_name: "Spina::Page", optional: true
-
-    # after_save :scope_pages_to_parent_page
-
     def pages
       case order_by
       when "title"
@@ -14,14 +10,6 @@ module Spina
         super.order(created_at: :desc)
       end
     end
-
-    # private
-
-    #   def scope_pages_to_parent_page
-    #     pages.roots.each do |root_page|
-    #       root_page.update(parent: parent_page)
-    #     end
-    #   end
-
+    
   end
 end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -2,9 +2,9 @@ module Spina
   class Resource < ApplicationRecord
     has_many :pages, dependent: :restrict_with_exception
 
-    belongs_to :parent_page, class_name: "Spina::Page", optional: true
+    # belongs_to :parent_page, class_name: "Spina::Page", optional: true
 
-    after_save :scope_pages_to_parent_page
+    # after_save :scope_pages_to_parent_page
 
     def pages
       case order_by
@@ -15,13 +15,13 @@ module Spina
       end
     end
 
-    private
+    # private
 
-      def scope_pages_to_parent_page
-        pages.roots.each do |root_page|
-          root_page.update(parent: parent_page)
-        end
-      end
+    #   def scope_pages_to_parent_page
+    #     pages.roots.each do |root_page|
+    #       root_page.update(parent: parent_page)
+    #     end
+    #   end
 
   end
 end

--- a/app/views/spina/admin/pages/_form_advanced.html.haml
+++ b/app/views/spina/admin/pages/_form_advanced.html.haml
@@ -34,12 +34,13 @@
           = f.text_field :link_url, placeholder: Spina::Page.human_attribute_name(:link_url_placeholder)
 
     .well
-      .horizontal-form-group
-        .horizontal-form-label
-          = Spina::Page.human_attribute_name :ancestry
-        .horizontal-form-content
-          .select-dropdown.ancestry
-            = f.select :parent_id, page_ancestry_options(f.object), include_blank: Spina::Page.human_attribute_name(:no_parent)
+      - unless @page.resource.present?
+        .horizontal-form-group
+          .horizontal-form-label
+            = Spina::Page.human_attribute_name :ancestry
+          .horizontal-form-content
+            .select-dropdown.ancestry
+              = f.select :parent_id, page_ancestry_options(f.object), include_blank: Spina::Page.human_attribute_name(:no_parent)
 
       .horizontal-form-group{style: ('display: none' if @page.custom_page?)}
         .horizontal-form-label
@@ -49,9 +50,10 @@
             - options = options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name], {'data-page-parts' => template[:page_parts]}] }, @page.view_template)
             = f.select :view_template, options
 
-      .horizontal-form-group
-        .horizontal-form-label
-          = Spina::Page.human_attribute_name :resource
-        .horizontal-form-content
-          .select-dropdown
-            = f.select :resource_id, Spina::Resource.order(:label).pluck(:label, :id), include_blank: t('spina.website.pages')
+      - if @page.root?
+        .horizontal-form-group
+          .horizontal-form-label
+            = Spina::Page.human_attribute_name :resource
+          .horizontal-form-content
+            .select-dropdown
+              = f.select :resource_id, Spina::Resource.order(:label).pluck(:label, :id), include_blank: t('spina.website.pages')

--- a/app/views/spina/admin/resources/edit.html.haml
+++ b/app/views/spina/admin/resources/edit.html.haml
@@ -40,10 +40,3 @@
           .select-dropdown
             - options = options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name]] }, @resource.view_template)
             = f.select :view_template, options, include_blank: true
-
-      .horizontal-form-group
-        .horizontal-form-label
-          = Spina::Resource.human_attribute_name :parent_page
-        .horizontal-form-content
-          .select-dropdown
-            = f.select :parent_page_id, page_ancestry_options(Spina::Page.new), include_blank: Spina::Resource.human_attribute_name(:no_parent)

--- a/app/views/spina/admin/resources/show.html.haml
+++ b/app/views/spina/admin/resources/show.html.haml
@@ -9,7 +9,7 @@
 .well
   .dd#pages_list
     %ol.dd-list
-      - (@resource.parent_page.try(:children) || @resource.pages.roots).each do |page|
+      - @resource.pages.roots.each do |page|
         %li.dd-item{data: {controller: "page-collapse", url: spina.children_admin_page_path(page)}}
           .dd-item-inner
             - if page.children.any?

--- a/db/migrate/11_create_spina_resources.rb
+++ b/db/migrate/11_create_spina_resources.rb
@@ -4,12 +4,10 @@ class CreateSpinaResources < ActiveRecord::Migration[5.1]
       t.string :name, null: false, unique: true
       t.string :label
       t.string :view_template
-      t.integer :parent_page_id
       t.string :order_by
       t.timestamps
     end
     add_column :spina_pages, :resource_id, :integer, null: true
     add_index :spina_pages, :resource_id
-    add_index :spina_resources, :parent_page_id
   end
 end

--- a/docs/themes/5_resources.md
+++ b/docs/themes/5_resources.md
@@ -30,6 +30,3 @@ Every resource can have the following attributes:
 - label
 - view_template
 - order_by
-- parent_page_id
-
-When defining a parent page, all pages within that resource will be scoped to that parent page. This means that all generated URL's will be prefixed with the parent page's URL. An example: you can create a regular page called `blog` and have a resource called `blogposts`. Your blog view template could then list all pages that are inside the blog resource. In Spina you would have a nice separate menu called "Blogposts" where you can easily manage a list of blogposts. 


### PR DESCRIPTION
There are some weird inconsistencies when using `Spina::Resource`, mainly related to mismatches between parent pages and resources. I've added a `before_save` callback on pages so that you can't have nested pages belonging to a different resource than their parent. Also removed the option to have a default parent page for resource pages, because that interferes with this logic.

Instead I propose we simply add a `slug` field for both `Spina::Resource` and `Spina::Page`. That will enable us to do two things:
- Scope resource pages to a specific path (i.e. blogposts could live in /blog)
- Customize the materialized_path directly by editing slugs on pages (applies to all pages)