### PR TITLE
Trix toolbar sticky - Fixes #579

### DIFF
--- a/app/assets/javascripts/spina/admin/scaffold.coffee
+++ b/app/assets/javascripts/spina/admin/scaffold.coffee
@@ -65,6 +65,7 @@ ready = ->
   if header = document.getElementById('header')
     headerHeight = header.getBoundingClientRect().height
     $('section#main').css({paddingTop: headerHeight})
+    $('section#main trix-toolbar').css({top: headerHeight + 15})
 
   # Login wrapper
   $('#login_wrapper').css('margin-top', $(document).innerHeight() / 8)

--- a/app/assets/stylesheets/spina/_trix_custom.sass
+++ b/app/assets/stylesheets/spina/_trix_custom.sass
@@ -1,6 +1,9 @@
 trix-toolbar
+  position: sticky
+
   .trix-button-group
     border: 0
+    margin-bottom: 0
 
     &:not(:first-child)
       margin-left: 10px
@@ -91,6 +94,7 @@ trix-toolbar
 trix-editor
   line-height: 18px
   min-height: 100px
+  margin-top: 15px
 
   h1, h2, h3, h4, h5, h6
     padding-left: 24px

--- a/app/assets/stylesheets/spina/_trix_custom.sass
+++ b/app/assets/stylesheets/spina/_trix_custom.sass
@@ -1,5 +1,6 @@
 trix-toolbar
   position: sticky
+  z-index: 2
 
   .trix-button-group
     border: 0
@@ -99,6 +100,7 @@ trix-editor
   h1, h2, h3, h4, h5, h6
     padding-left: 24px
     position: relative
+    z-index: 1
 
     &:after
       color: #ccc
@@ -205,7 +207,7 @@ trix-editor
       white-space: nowrap
       width: auto
 
-  figure[data-trix-mutable] 
+  figure[data-trix-mutable]
     .trix-attachment-spina-image:before
       background: $primary-color
       color: white
@@ -215,4 +217,4 @@ trix-editor
 
   .trix-button--remove
     border: none
-    box-shadow: 0 0 5px rgba(0, 0, 0, .15) 
+    box-shadow: 0 0 5px rgba(0, 0, 0, .15)


### PR DESCRIPTION
Make the toolbar in trix sticky. Adding the correct `top` to the toolbar happens in javascript, just like adding `paddingTop` for `section#main`.