### PR TITLE
Strip HTML & truncate repeater text

### DIFF
--- a/app/assets/stylesheets/spina/_forms.sass
+++ b/app/assets/stylesheets/spina/_forms.sass
@@ -677,13 +677,14 @@ input.datepicker
     ul li a, ul li.sortable-placeholder
       color: #444
       cursor: pointer
-      display: block
+      display: flex
       font-weight: 600
       font-size: 13px
       height: 44px
       line-height: 44px
       outline: none
       padding-left: 20px
+      padding-right: 6px
 
       &:hover
         background: #f9f9f9
@@ -693,6 +694,11 @@ input.datepicker
         font-size: 16px
         margin-right: 8px
         vertical-align: middle
+
+      span
+        white-space: nowrap
+        overflow: hidden
+        text-overflow: ellipsis
 
     ul li.sortable-placeholder
       background: #f9f9f9

--- a/app/views/spina/admin/parts/repeaters/_form.html.haml
+++ b/app/views/spina/admin/parts/repeaters/_form.html.haml
@@ -7,12 +7,11 @@
           %li{class: ('active' if index.zero?), data: {part_id: repeater_content.object_id, target: "repeater-form.listItem"}}
             = link_to "#structure_form_pane_#{repeater_content.object_id}" do
               %i.icon.icon-bars.sortable-handle
-              = repeater_content.parts&.first&.content
+              %span= strip_tags(repeater_content.parts&.first&.content)
 
       %div{style: "margin-top: 6px; margin-left: 6px"}
         = link_to_add_repeater_fields f do
           = icon('plus')
-
     .structure-form-content{data: {target: "repeater-form.content"}}
       = f.fields_for :content do |ff|
         = render 'spina/admin/parts/repeaters/fields', f: ff


### PR DESCRIPTION
### Context

Cleans up repeater text in the admin to truncate if too long, and to strip HTML if a text part is the first field

The reason for the `display: flex` change can be seen [on CodePen](https://codepen.io/markmead/pen/dyXPOpb)