### PR TITLE
Force the part content to be a string with to_s for strip_tags

### DIFF
--- a/app/views/spina/admin/parts/repeaters/_form.html.haml
+++ b/app/views/spina/admin/parts/repeaters/_form.html.haml
@@ -7,7 +7,7 @@
           %li{class: ('active' if index.zero?), data: {part_id: repeater_content.object_id, target: "repeater-form.listItem"}}
             = link_to "#structure_form_pane_#{repeater_content.object_id}" do
               %i.icon.icon-bars.sortable-handle
-              %span= strip_tags(repeater_content.parts&.first&.content)
+              %span= strip_tags(repeater_content.parts&.first&.content.to_s)
 
       %div{style: "margin-top: 6px; margin-left: 6px"}
         = link_to_add_repeater_fields f do


### PR DESCRIPTION
#622 introduced `strip_tags` for the labels in repeaters. When using parts that aren't strings, it'll produce an error because it won't respond to `empty?`. This makes sure it's a string before it's passed to `strip_tags`.