### PR TITLE
Bump Mobility to 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       jsonb_accessor (>= 1.0.0)
       kaminari
       mini_magick
-      mobility (>= 0.8.9)
+      mobility (= 1.0.0)
       pg
       rack-rewrite (>= 1.5.0)
       rails (>= 5.2)
@@ -168,7 +168,7 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mobility (0.8.13)
+    mobility (1.0.0)
       i18n (>= 0.6.10, < 2)
       request_store (~> 1.0)
     mocha (1.11.2)

--- a/lib/generators/spina/templates/config/initializers/mobility.rb
+++ b/lib/generators/spina/templates/config/initializers/mobility.rb
@@ -1,5 +1,14 @@
-Mobility.configure do |config|
-  config.default_backend = :table
-  config.accessor_method = :translates
-  config.query_method    = :i18n
+Mobility.configure do
+  plugins do
+    backend :table
+    active_record
+    reader
+    writer
+    backend_reader
+    query
+    cache
+    presence
+    fallbacks false # default to false, enable if passed fallbacks: true
+    default
+  end
 end

--- a/lib/tasks/spina_tasks.rake
+++ b/lib/tasks/spina_tasks.rake
@@ -11,7 +11,7 @@ namespace :spina do
       Mobility.with_locale(locale) do
 
         Spina::Page.all.order(:id).each do |page|
-          page.title = page.title(fallback: Mobility.new_fallbacks[locale])
+          page.title = page.title(fallback: I18n.fallbacks[locale])
           page.save
         end
 

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'turbolinks', '~> 5'
   s.add_dependency 'kaminari'
-  s.add_dependency 'mobility', '>= 0.8.9'
+  s.add_dependency 'mobility', '1.0.0'
   s.add_dependency 'rack-rewrite', '>= 1.5.0'
   s.add_dependency 'jsonb_accessor', '>= 1.0.0'
   s.add_dependency 'attr_json'

--- a/test/dummy/config/initializers/mobility.rb
+++ b/test/dummy/config/initializers/mobility.rb
@@ -1,5 +1,14 @@
-Mobility.configure do |config|
-  config.default_backend = :table
-  config.accessor_method = :translates
-  config.query_method    = :i18n
+Mobility.configure do
+  plugins do
+    backend :table
+    active_record
+    reader
+    writer
+    backend_reader
+    query
+    cache
+    presence
+    fallbacks false # default to false, enable if passed fallbacks: true
+    default
+  end
 end


### PR DESCRIPTION
### Context

I'm working on releasing a 1.0 of Mobility, which requires changes to configuration. Currently there's a 1.0.0.beta pre-release version, and I'd like to see how Spina tests run with this version and updated configuration.

### Changes proposed in this pull request

Bump gem version and Mobility configs. Otherwise nothing should change :crossed_fingers: 

### Guidance to review

Bumping Mobility would require applications to also bump their configs. Not sure how that would work.