### PR TITLE
Cleaning whitespace in themes/deafult.rb initializer

### DIFF
--- a/lib/generators/spina/templates/config/initializers/themes/default.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/default.rb
@@ -30,7 +30,7 @@
 
   theme.navigations = [{
     name: 'mobile',
-    label: 'Mobile'  
+    label: 'Mobile'
   }, {
     name: 'main',
     label: 'Main navigation',


### PR DESCRIPTION
Such a small nit pick, but the generated default theme's initializer has some trailing whitespace, cleaned up here in this PR 
