### PR TITLE
Fixing keys in the generator for the themes/default.rb initializer

### DIFF
--- a/lib/generators/spina/templates/config/initializers/themes/default.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/default.rb
@@ -12,13 +12,13 @@
   theme.view_templates = [{
     name:       'homepage',
     title:      'Homepage',
-    page_parts: ['text']
+    parts: ['text']
   }, {
     name: 'show',
     title:        'Default',
     description:  'A simple page',
     usage:        'Use for your content',
-    page_parts:   ['text']
+    parts:   ['text']
   }]
 
   theme.custom_pages = [{


### PR DESCRIPTION
There are incorrect keys in the themes initializer generator. This causes the admin panel to not display any page parts in the admin panel for a freshly generated Spina installation.
