### PR TITLE
Better path generation - Fixes #655

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -126,7 +126,7 @@ module Spina
       end
       
       def duplicate_materialized_path?
-        self.class.where.not(id: id).i18n.where(materialized_path: materialized_path).count > 0
+        self.class.where.not(id: id).i18n.where(materialized_path: materialized_path).exists?
       end
 
   end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -74,12 +74,17 @@ module Spina
     def next_sibling
       siblings.where('position > ?', position).sorted.first
     end
-
+    
     def set_materialized_path
       self.old_path = materialized_path
       self.materialized_path = localized_materialized_path
-      self.materialized_path = localized_materialized_path + "-#{Page.i18n.where(materialized_path: materialized_path).count}" if Page.i18n.where(materialized_path: materialized_path).where.not(id: id).count > 0
-      materialized_path
+      
+      # Append counter to duplicate materialized_path
+      i = 0
+      while duplicate_materialized_path?
+        i += 1
+        self.materialized_path = localized_materialized_path.concat("-#{i}")
+      end
     end
 
     def cache_key
@@ -118,6 +123,10 @@ module Spina
         path_fragments.append *ancestors.collect(&:slug)
         path_fragments.append(slug) unless name == 'homepage'
         path_fragments.compact.map(&:parameterize).join('/')
+      end
+      
+      def duplicate_materialized_path?
+        self.class.where.not(id: id).i18n.where(materialized_path: materialized_path).count > 0
       end
 
   end

--- a/test/models/spina/page_test.rb
+++ b/test/models/spina/page_test.rb
@@ -36,6 +36,23 @@ module Spina
       page.update(parent: about)
       assert_equal "/about/services", page.materialized_path
     end
+    
+    test 'append decimal to duplicate paths' do
+      page = FactoryBot.create :about_page, title: "About"
+      assert_equal "/about", page.materialized_path
+      
+      duplicate_page = FactoryBot.create :about_page, title: "About"
+      assert_equal "/about-1", duplicate_page.materialized_path
+    end
+    
+    test 'append decimal to multiple duplicate paths' do
+      2.times do
+        FactoryBot.create :about_page, title: "About"
+      end
+      
+      page = FactoryBot.create :about_page, title: "About"
+      assert_equal "/about-2", page.materialized_path
+    end
 
   end
 end


### PR DESCRIPTION
We previously only checked for duplicate localized_material_paths and added a `-[count]` at the end. But because of the way it was programmed that only works once (adding -1). Fixed it using a while loop. Added tests as well.