### PR TITLE
Changing CDN for html5shiv cdnjs

### DIFF
--- a/app/assets/icons/spina/preview/icons_spina-preview.html
+++ b/app/assets/icons/spina/preview/icons_spina-preview.html
@@ -288,7 +288,7 @@
 .icon-users-outline:before { content: "\f107"; }
     </style>
 
-    <!--[if lte IE 8]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+    <!--[if lte IE 8]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script><![endif]-->
 
     <script>
       function toggleCharacters() {

--- a/app/assets/icons/spina/preview/icons_spina-preview.html
+++ b/app/assets/icons/spina/preview/icons_spina-preview.html
@@ -288,8 +288,6 @@
 .icon-users-outline:before { content: "\f107"; }
     </style>
 
-    <!--[if lte IE 8]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script><![endif]-->
-
     <script>
       function toggleCharacters() {
         var body = document.getElementsByTagName('body')[0];

--- a/app/assets/icons/spina/preview/ics_spina-preview.html
+++ b/app/assets/icons/spina/preview/ics_spina-preview.html
@@ -309,8 +309,6 @@
 .icon-users-outline:before { content: "\f137"; }
     </style>
 
-    <!--[if lte IE 8]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script><![endif]-->
-
     <script>
       function toggleCharacters() {
         var body = document.getElementsByTagName('body')[0];

--- a/app/assets/icons/spina/preview/ics_spina-preview.html
+++ b/app/assets/icons/spina/preview/ics_spina-preview.html
@@ -309,7 +309,7 @@
 .icon-users-outline:before { content: "\f137"; }
     </style>
 
-    <!--[if lte IE 8]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+    <!--[if lte IE 8]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script><![endif]-->
 
     <script>
       function toggleCharacters() {

--- a/app/views/layouts/spina/admin/admin.html.haml
+++ b/app/views/layouts/spina/admin/admin.html.haml
@@ -13,9 +13,6 @@
     / Stylesheet
     = stylesheet_link_tag 'spina/admin/application', data: {turbolinks_track: true}
 
-    /[if lt IE 9]
-      = javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js', data: {turbolinks_track: true}
-
     / JavaScript
     = javascript_include_tag 'spina/admin/application', data: {turbolinks_track: true}
     = yield(:plugin_stylesheets)

--- a/app/views/layouts/spina/admin/admin.html.haml
+++ b/app/views/layouts/spina/admin/admin.html.haml
@@ -14,7 +14,7 @@
     = stylesheet_link_tag 'spina/admin/application', data: {turbolinks_track: true}
 
     /[if lt IE 9]
-      = javascript_include_tag '//html5shiv.googlecode.com/svn/trunk/html5.js', data: {turbolinks_track: true}
+      = javascript_include_tag '//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js', data: {turbolinks_track: true}
 
     / JavaScript
     = javascript_include_tag 'spina/admin/application', data: {turbolinks_track: true}

--- a/app/views/layouts/spina/login.html.haml
+++ b/app/views/layouts/spina/login.html.haml
@@ -11,7 +11,7 @@
     = stylesheet_link_tag "spina/admin/application"
 
     /[if lt IE 9]
-      = javascript_include_tag "//html5shiv.googlecode.com/svn/trunk/html5.js"
+      = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"
 
     / JavaScript
     = javascript_include_tag "spina/admin/application"

--- a/app/views/layouts/spina/login.html.haml
+++ b/app/views/layouts/spina/login.html.haml
@@ -10,9 +10,6 @@
     / Stylesheet
     = stylesheet_link_tag "spina/admin/application"
 
-    /[if lt IE 9]
-      = javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"
-
     / JavaScript
     = javascript_include_tag "spina/admin/application"
 


### PR DESCRIPTION
### Context

Googlecode no longer seems to host the html5shiv code. Issue: #663 

### Changes proposed in this pull request

Change CDNs from Googlecode to cdnjs

### Guidance to review
