### PR TITLE
Add frontend parent controller config

### DIFF
--- a/app/controllers/concerns/spina/current_methods.rb
+++ b/app/controllers/concerns/spina/current_methods.rb
@@ -1,0 +1,26 @@
+module Spina
+  module CurrentMethods
+    extend ActiveSupport::Concern
+    
+    included do
+      helper_method :current_theme
+      helper_method :current_spina_user
+      helper_method :current_account
+    end
+  
+    private
+    
+      def current_theme
+        @current_theme ||= Spina::Theme.find_by_name(current_account.theme)
+      end
+      
+      def current_spina_user
+        @current_spina_user ||= Spina::User.where(id: session[:user_id]).first if session[:user_id]
+      end
+    
+      def current_account
+        @current_account ||= Spina::Account.first
+      end
+        
+  end
+end

--- a/app/controllers/spina/admin/admin_controller.rb
+++ b/app/controllers/spina/admin/admin_controller.rb
@@ -1,6 +1,10 @@
 module Spina
   module Admin
-    class AdminController < ::Spina::ApplicationController
+    class AdminController < ActionController::Base
+      include Spina::CurrentMethods
+      
+      helper Spina::Engine.helpers
+      
       before_action :set_admin_locale
       before_action :authorize_spina_user
 

--- a/app/controllers/spina/application_controller.rb
+++ b/app/controllers/spina/application_controller.rb
@@ -1,23 +1,7 @@
-class Spina::ApplicationController < Spina.parent_controller.constantize
-  protect_from_forgery with: :exception
+class Spina::ApplicationController < Spina.frontend_parent_controller.constantize
+  include Spina::CurrentMethods
   
   helper Spina::Engine.helpers
-
-  private
-
-    def current_theme
-      @current_theme ||= Spina::Theme.find_by_name(current_account.theme)
-    end
-    helper_method :current_theme
   
-    def current_spina_user
-      @current_spina_user ||= Spina::User.where(id: session[:user_id]).first if session[:user_id]
-    end
-    helper_method :current_spina_user
-  
-    def current_account
-      @current_account ||= Spina::Account.first
-    end
-    helper_method :current_account
-    
+  protect_from_forgery with: :exception
 end

--- a/app/controllers/spina/application_controller.rb
+++ b/app/controllers/spina/application_controller.rb
@@ -1,24 +1,23 @@
-module Spina
-  class ApplicationController < ActionController::Base
+class Spina::ApplicationController < Spina.parent_controller.constantize
+  protect_from_forgery with: :exception
+  
+  helper Spina::Engine.helpers
 
-    protect_from_forgery with: :exception
-
-    private
+  private
 
     def current_theme
-      @current_theme ||= ::Spina::Theme.find_by_name(current_account.theme)
+      @current_theme ||= Spina::Theme.find_by_name(current_account.theme)
     end
     helper_method :current_theme
-
+  
     def current_spina_user
-      @current_spina_user ||= ::Spina::User.where(id: session[:user_id]).first if session[:user_id]
+      @current_spina_user ||= Spina::User.where(id: session[:user_id]).first if session[:user_id]
     end
     helper_method :current_spina_user
-
+  
     def current_account
-      @current_account ||= ::Spina::Account.first
+      @current_account ||= Spina::Account.first
     end
     helper_method :current_account
-
-  end
+    
 end

--- a/app/controllers/spina/pages_controller.rb
+++ b/app/controllers/spina/pages_controller.rb
@@ -1,20 +1,18 @@
-module Spina
-  class PagesController < Spina::ApplicationController
-    include Spina::Frontend
+class Spina::PagesController < Spina::ApplicationController
+  include Spina::Frontend
 
-    before_action :current_spina_user_can_view_page?, except: [:robots]
+  before_action :current_spina_user_can_view_page?, except: [:robots]
 
-    helper_method :page
+  helper_method :page
 
-    def homepage
-      render_with_template(page)
+  def homepage
+    render_with_template(page)
+  end
+
+  private
+
+    def current_spina_user_can_view_page?
+      raise ActiveRecord::RecordNotFound unless current_spina_user.present? || page.live?
     end
 
-    private
-
-      def current_spina_user_can_view_page?
-        raise ActiveRecord::RecordNotFound unless current_spina_user.present? || page.live?
-      end
-
-  end
 end

--- a/app/controllers/spina/sitemaps_controller.rb
+++ b/app/controllers/spina/sitemaps_controller.rb
@@ -1,8 +1,8 @@
-module Spina
-  class SitemapsController < Spina::ApplicationController
-    def show
-      I18n.locale = I18n.default_locale
-      @pages = Page.live.sorted
-    end
+class Spina::SitemapsController < Spina::ApplicationController
+  
+  def show
+    I18n.locale = I18n.default_locale
+    @pages = Spina::Page.live.sorted
   end
+  
 end

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -12,9 +12,9 @@ Spina.configure do |config|
   # Specify a backend path. Defaults to /admin.
   # config.backend_path = 'admin'
   
-  # The parent controller all Spina controllers inherit from
+  # The parent controller all frontend Spina controllers inherit from
   # Defaults to ApplicationController
-  # config.parent_controller = "ApplicationController"
+  # config.frontend_parent_controller = "ApplicationController"
 
   # Pages Options
   # ===============

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -11,6 +11,10 @@ Spina.configure do |config|
 
   # Specify a backend path. Defaults to /admin.
   # config.backend_path = 'admin'
+  
+  # The parent controller all Spina controllers inherit from
+  # Defaults to ApplicationController
+  # config.parent_controller = "ApplicationController"
 
   # Pages Options
   # ===============

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -13,7 +13,7 @@ module Spina
   THEMES = []
 
   config_accessor :backend_path, 
-                  :parent_controller,
+                  :frontend_parent_controller,
                   :disable_frontend_routes,
                   :max_page_depth, 
                   :locales, 
@@ -22,9 +22,9 @@ module Spina
   # Specify a backend path. Defaults to /admin.
   self.backend_path = 'admin'
   
-  # The parent controller all Spina controllers inherit from
+  # The parent controller all frontend Spina controllers inherit from
   # Default is ApplicationController
-  self.parent_controller = "ApplicationController"
+  self.frontend_parent_controller = "ApplicationController"
 
   self.disable_frontend_routes = false
 

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -12,13 +12,21 @@ module Spina
   PLUGINS = []
   THEMES = []
 
-  config_accessor :backend_path, :disable_frontend_routes, :storage, :max_page_depth, :locales, :embedded_image_size
+  config_accessor :backend_path, 
+                  :parent_controller,
+                  :disable_frontend_routes,
+                  :max_page_depth, 
+                  :locales, 
+                  :embedded_image_size
 
+  # Specify a backend path. Defaults to /admin.
   self.backend_path = 'admin'
+  
+  # The parent controller all Spina controllers inherit from
+  # Default is ApplicationController
+  self.parent_controller = "ApplicationController"
 
   self.disable_frontend_routes = false
-
-  self.storage = :file
 
   self.max_page_depth = 5
 

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -19,10 +19,7 @@ module Spina
 
     config.autoload_paths += %W( #{config.root}/lib )
 
-    config.to_prepare do
-      # Load helpers from main application
-      Spina::ApplicationController.helper Rails.application.helpers
-
+    config.to_prepare do    
       # Require decorators from main application
       [Rails.root].flatten.map { |p| Dir[p.join('app', 'decorators', '**', '*_decorator.rb')]}.flatten.uniq.each do |decorator|
         Rails.configuration.cache_classes ? require(decorator) : load(decorator)

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :set_some_variable
+  
+  private
+  
+    def set_some_variable
+      @some_variable = "Some variable is set!"
+    end
+  
 end

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+
+  def some_helper_method
+    "This is some helper method"
+  end
+  
 end

--- a/test/dummy/app/views/demo/pages/homepage.html.haml
+++ b/test/dummy/app/views/demo/pages/homepage.html.haml
@@ -1,2 +1,5 @@
 %h1= current_page.title
+
 = content.html :body
+
+= some_helper_method

--- a/test/dummy/config/initializers/spina.rb
+++ b/test/dummy/config/initializers/spina.rb
@@ -12,9 +12,9 @@ Spina.configure do |config|
   # Specify a backend path. Defaults to /admin.
   # config.backend_path = 'admin'
   
-  # The parent controller all Spina controllers inherit from
+  # The parent controller all frontend Spina controllers inherit from
   # Defaults to ApplicationController
-  # config.parent_controller = "ApplicationController"
+  # config.frontend_parent_controller = "ApplicationController"
 
   # Pages Options
   # ===============

--- a/test/dummy/config/initializers/spina.rb
+++ b/test/dummy/config/initializers/spina.rb
@@ -11,6 +11,10 @@ Spina.configure do |config|
 
   # Specify a backend path. Defaults to /admin.
   # config.backend_path = 'admin'
+  
+  # The parent controller all Spina controllers inherit from
+  # Defaults to ApplicationController
+  # config.parent_controller = "ApplicationController"
 
   # Pages Options
   # ===============

--- a/test/functional/spina/pages_controller_test.rb
+++ b/test/functional/spina/pages_controller_test.rb
@@ -12,5 +12,11 @@ module Spina
       get :homepage
       assert_response :success
     end
+    
+    test "instance variable from parent application controller is set" do
+      get :homepage
+      assert_not_nil assigns(:some_variable)
+    end
+    
   end
 end

--- a/test/integration/spina/pages_test.rb
+++ b/test/integration/spina/pages_test.rb
@@ -50,5 +50,11 @@ module Spina
       get "/nl/over-ons"
       assert_select 'h1', 'Over ons'
     end
+    
+    test "helper methods parent app" do
+      get "/"
+      assert_select 'body', /This is some helper method/
+    end
+    
   end
 end


### PR DESCRIPTION
New configuration option added: `Spina.config.frontend_parent_controller`
All frontend Spina controllers will inherit from this controller. Default value is `ApplicationController`.

This change makes it easier to add your own functionality without having to override Spina internals using decorators.