### PR TITLE
fix: use correct indexof sorting for repeater parts

### DIFF
--- a/app/assets/javascripts/spina/admin/controllers/repeater_form_controller.js
+++ b/app/assets/javascripts/spina/admin/controllers/repeater_form_controller.js
@@ -17,7 +17,7 @@
           // Sort the DOM elements containing the repeater fields
           let array = [...this.contentTarget.children]
           array.sort(function(a, b) {
-            return order_of_ids.indexOf(parseInt(a.dataset.partId)) > order_of_ids.indexOf(parseInt(b.dataset.partId))
+            return order_of_ids.indexOf(parseInt(a.dataset.partId)) - order_of_ids.indexOf(parseInt(b.dataset.partId))
           }).map(node => this.contentTarget.appendChild(node))
         }.bind(this)
       })


### PR DESCRIPTION
### Context
The sorting of the new repeater function is not working properly

### Changes proposed in this pull request
The comparison in the sort was not correct 

### Guidance to review
Add a repeatable parts to your page and try to change the sorting 