### PR TITLE
ActiveStorage variant definitions use ImageProcessing gem macros

### DIFF
--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -8,7 +8,7 @@ module Spina
 
     def embedded_image_url(image)
       return "" if image.nil?
-      main_app.url_for(image.variant(resize_to_fit: Spina.config.embedded_image_size))
+      main_app.url_for(image.variant(resize_to_limit: Spina.config.embedded_image_size))
     end
 
   end

--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -8,7 +8,15 @@ module Spina
 
     def embedded_image_url(image)
       return "" if image.nil?
-      main_app.url_for(image.variant(resize_to_limit: Spina.config.embedded_image_size))
+
+      # support both ImageProcessing gem macro :resize_to_limit and ImageMagick-specific :resize
+      resize_key = if !Spina.config.embedded_image_size.is_a?(Array)
+                     :resize
+                   else
+                     :resize_to_limit
+                   end
+      byebug
+      main_app.url_for(image.variant(Hash[resize_key, Spina.config.embedded_image_size]))
     end
 
   end

--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -15,7 +15,6 @@ module Spina
                    else
                      :resize_to_limit
                    end
-      byebug
       main_app.url_for(image.variant(Hash[resize_key, Spina.config.embedded_image_size]))
     end
 

--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -3,12 +3,12 @@ module Spina
 
     def thumbnail_url(image)
       return "" if image.nil?
-      main_app.url_for(image.variant(resize: "400x300^", crop: "400x300+0+0"))
+      main_app.url_for(image.variant(resize_to_fill: [400, 300]))
     end
 
     def embedded_image_url(image)
       return "" if image.nil?
-      main_app.url_for(image.variant(resize: Spina.config.embedded_image_size))
+      main_app.url_for(image.variant(resize_to_fit: Spina.config.embedded_image_size))
     end
 
   end

--- a/app/views/spina/admin/images/_image.html.haml
+++ b/app/views/spina/admin/images/_image.html.haml
@@ -5,4 +5,4 @@
         = t('spina.images.delete')
       %span.photo-name= truncate(image.name, length: 125)
 
-  = image_tag main_app.url_for(image.variant(resize: '300x300^', crop: "300x300+0+0"))
+  = image_tag main_app.url_for(image.variant(resize_to_fill: [300, 300]))

--- a/app/views/spina/admin/media_folders/_media_folder.html.haml
+++ b/app/views/spina/admin/media_folders/_media_folder.html.haml
@@ -1,7 +1,7 @@
 = link_to [:admin, media_folder], class: 'item media-folder', data: {add_to_media_folder_url: add_to_media_folder_admin_images_url(media_folder)} do
   .media-folder-thumbnail{data: {badge: media_folder.images.count}}
     - if media_folder.images.any?
-      = image_tag main_app.url_for(media_folder.images.last.variant(resize: '144x144^', crop: "144x144+0+0"))
+      = image_tag main_app.url_for(media_folder.images.last.variant(resize_to_fill: [144, 144]))
     - else
       = image_tag 'spina/media_folder_placeholder.svg'
     .media-folder-shadow

--- a/app/views/spina/admin/media_picker/_media_picker_grid.html.haml
+++ b/app/views/spina/admin/media_picker/_media_picker_grid.html.haml
@@ -15,7 +15,7 @@
     - @media_folders.each do |media_folder|
       = link_to spina.admin_media_picker_path(media_folder_id: media_folder.id), class: 'media-folder', data: {action: "media-picker#openFolder"} do
         .media-folder-thumbnail{data: {badge: media_folder.images.size}}
-          = image_tag main_app.url_for(media_folder.images.last.variant(resize: '144x144^', crop: "144x144+0+0"))
+          = image_tag main_app.url_for(media_folder.images.last.variant(resize_to_fill: [144, 144]))
           .media-folder-shadow
         .media-folder-name= media_folder.name
 

--- a/app/views/spina/admin/media_picker/_modal.html.haml
+++ b/app/views/spina/admin/media_picker/_modal.html.haml
@@ -16,7 +16,7 @@
             = link_to spina.admin_media_picker_path({media_folder_id: media_folder.id}.merge(request.query_parameters)), class: 'item media-folder', data: {remote: true} do
               .media-folder-thumbnail{data: {badge: media_folder.images.count}}
                 - if media_folder.images.any?
-                  = image_tag main_app.url_for(media_folder.images.last.variant(resize: '144x144^', crop: "144x144+0+0"))
+                  = image_tag main_app.url_for(media_folder.images.last.variant(resize_to_fill: [144, 144]))
                 - else
                   = image_tag 'spina/media_folder_placeholder.svg'
                 .media-folder-shadow

--- a/app/views/spina/admin/media_picker/select.js.erb
+++ b/app/views/spina/admin/media_picker/select.js.erb
@@ -5,7 +5,7 @@ hidden_input.val("");
 <% if @image.present? %>
   hidden_input.parents('.media_picker').append("<%=j render partial: 'spina/admin/images/image', object: @image, locals: {simple: true} %>");
   hidden_input.parents('[data-controller="image-form"]').find(".image img").remove();
-  hidden_input.parents('[data-controller="image-form"]').find(".image")[0].insertAdjacentHTML("beforeend", `<%=j image_tag main_app.url_for(@image.variant(resize: "400x300^", crop: "400x300+0+0")), width: 200, height: 150 %>`)
+  hidden_input.parents('[data-controller="image-form"]').find(".image")[0].insertAdjacentHTML("beforeend", `<%=j image_tag main_app.url_for(@image.variant(resize_to_fill: [400, 300])), width: 200, height: 150 %>`)
   hidden_input.val("<%= @image.id %>");
 
   // Trix editor

--- a/app/views/spina/admin/parts/image_collections/_fields.html.haml
+++ b/app/views/spina/admin/parts/image_collections/_fields.html.haml
@@ -2,6 +2,6 @@
 = f.hidden_field :signed_blob_id, class: 'signed-blob-id'
 = f.hidden_field :filename, class: 'filename'
 - if f.object.signed_blob_id.present? && f.object.spina_image
-  = image_tag main_app.url_for(f.object.spina_image.variant(resize: "400x300^", crop: "400x300+0+0"))
+  = image_tag main_app.url_for(f.object.spina_image.variant(resize_to_fill: [400, 300]))
 - else
   = image_tag ""

--- a/app/views/spina/admin/parts/images/_form.html.haml
+++ b/app/views/spina/admin/parts/images/_form.html.haml
@@ -10,7 +10,7 @@
           = f.hidden_field :filename, data: {target: 'image-form.filename'}
         %div{style: "width: 200px; height: 150px; overflow: hidden"}
           - if f.object.signed_blob_id.present? && f.object.spina_image.present?
-            = image_tag main_app.url_for(f.object.spina_image.variant(resize: "400x300^", crop: "400x300+0+0")), width: 200, height: 150
+            = image_tag main_app.url_for(f.object.spina_image.variant(resize_to_fill: [400, 300])), width: 200, height: 150
 
       = f.text_field :alt, placeholder: "Alt text", class: 'page-form-media-picker-alt-text'
 

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -35,6 +35,6 @@ module Spina
   # Images that are embedded in the Trix editor are resized to fit
   # You can optimize this for your website and go for a smaller (or larger) size
   # Default: 2000x2000px
-  self.embedded_image_size = "2000x2000>"
+  self.embedded_image_size = [2000, 2000]
 
 end

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -16,28 +16,8 @@ module Spina
                   :frontend_parent_controller,
                   :disable_frontend_routes,
                   :max_page_depth, 
-                  :locales, 
+                  :locales,
                   :embedded_image_size
-
-  # support embedded_image_size deprecation warning
-  class <<self
-    alias_method :config_original, :config
-  end
-
-  # support embedded_image_size deprecation warning
-  def self.config
-    config_obj = self.config_original
-
-    def config_obj.embedded_image_size=(image_size)
-      if image_size.is_a? String
-        warn("[DEPRECATION]: Spina embedded_image_size should be set to an array of arguments to be passed to the :resize_to_limit ImageProcessing macro. https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit")
-      end
-
-      self[:embedded_image_size] = image_size
-    end
-
-    config_obj
-  end
 
   # Specify a backend path. Defaults to /admin.
   self.backend_path = 'admin'
@@ -55,6 +35,24 @@ module Spina
   # Images that are embedded in the Trix editor are resized to fit
   # You can optimize this for your website and go for a smaller (or larger) size
   # Default: 2000x2000px
+  class << self
+    alias_method :config_original, :config
+    
+    def config
+      config_obj = self.config_original
+      
+      def config_obj.embedded_image_size=(image_size)
+        if image_size.is_a? String
+          ActiveSupport::Deprecation.warn("Spina embedded_image_size should be set to an array of arguments to be passed to the :resize_to_limit ImageProcessing macro. https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit")
+        end
+        
+        self[:embedded_image_size] = image_size
+      end
+      
+      config_obj
+    end
+  end
+  
   self.embedded_image_size = [2000, 2000]
 
 end

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -19,6 +19,26 @@ module Spina
                   :locales, 
                   :embedded_image_size
 
+  # support embedded_image_size deprecation warning
+  class <<self
+    alias_method :config_original, :config
+  end
+
+  # support embedded_image_size deprecation warning
+  def self.config
+    config_obj = self.config_original
+
+    def config_obj.embedded_image_size=(image_size)
+      if image_size.is_a? String
+        warn("[DEPRECATION]: Spina embedded_image_size should be set to an array of arguments to be passed to the :resize_to_limit ImageProcessing macro. https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit")
+      end
+
+      self[:embedded_image_size] = image_size
+    end
+
+    config_obj
+  end
+
   # Specify a backend path. Defaults to /admin.
   self.backend_path = 'admin'
   


### PR DESCRIPTION
### Context

ActiveStorage now uses the ImageProcessing gem which allows the use of libvips or imagemagick for variant processing via the config directive config.active_storage.variant_processor

### Changes proposed in this pull request

Instead of using imagemagick-specific resize and crop flags, use the macros provided by ImageProcessing so that users of Spina can set :vips as their variant processor.

### Guidance to review

Review macros being used.
