### PR TITLE
When uploading into a media library folder, the form must be set to remote:true

### DIFF
--- a/app/views/spina/admin/media_folders/show.html.haml
+++ b/app/views/spina/admin/media_folders/show.html.haml
@@ -5,7 +5,7 @@
 .gallery-container
   .gallery
     .item
-      = form_with model: [:admin, Spina::Image.new], id: 'new_image', class: 'new_image' do |f|
+      = form_with model: [:admin, Spina::Image.new], id: 'new_image', class: 'new_image', data: {remote: true} do |f|
         = f.submit style: 'display: none'
         = hidden_field_tag :media_library, @media_folder.id
         = f.label :file, t('spina.images.upload')


### PR DESCRIPTION
### Context

When using the Media Library to upload into a folder, an exception is thrown because the form displayed there did not set data-remote="true"

### Changes proposed in this pull request

Media Picker Library folder form sets data: { remote: true }

### Guidance to review
