### PR TITLE
Adding  Spina::Parts:Base#label

### DIFF
--- a/app/models/spina/parts/base.rb
+++ b/app/models/spina/parts/base.rb
@@ -7,6 +7,12 @@ module Spina
 
       attr_json :title, :string
       attr_json :name, :string
+
+      def label
+        content&.to_s
+      end
+
+      def content; end
     end
   end
 end

--- a/app/views/spina/admin/parts/repeaters/_form.html.haml
+++ b/app/views/spina/admin/parts/repeaters/_form.html.haml
@@ -7,7 +7,7 @@
           %li{class: ('active' if index.zero?), data: {part_id: repeater_content.object_id, target: "repeater-form.listItem"}}
             = link_to "#structure_form_pane_#{repeater_content.object_id}" do
               %i.icon.icon-bars.sortable-handle
-              %span= strip_tags(repeater_content.parts&.first&.content.to_s)
+              %span= strip_tags(repeater_content.parts&.first&.label)
 
       %div{style: "margin-top: 6px; margin-left: 6px"}
         = link_to_add_repeater_fields f do

--- a/test/factories/parts.rb
+++ b/test/factories/parts.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :base_part, class: Spina::Parts::Base do
+    skip_create
+
+    factory :line_part, class: Spina::Parts::Line do
+      content { 'a line of text' }
+    end
+  end
+end

--- a/test/models/spina/part_test.rb
+++ b/test/models/spina/part_test.rb
@@ -1,0 +1,16 @@
+module Spina
+  class PartTest < ActiveSupport::TestCase
+    def setup
+      @base_part = FactoryBot.create :base_part
+      @line_part = FactoryBot.create :line_part
+    end
+
+    test 'label returns nil with undefined content' do
+      assert_nil @base_part.label
+    end
+
+    test 'label defaults to content#to_s' do
+      assert_equal 'a line of text', @line_part.label
+    end
+  end
+end


### PR DESCRIPTION
### Context
This PR adds a `label` method to `Spina::Parts::Base`. This allows custom parts to define their own administrative labels instead of calling `content#to_s` which may not be applicable in some cases. 

For example:

``` ruby
module MyApp
  module CustomParts
    class Product < Spina::Parts::Base
      attr_json :product_id, :integer

      def content
        Product.find(product_id)
      end

      def label
        content&.name
      end
    end
  end
end
```

I've defined `Spina::Parts::Base#content` for testing purposes but additionally to indicate that this method is expected to be present in subclasses.