### PR TITLE
Add importmap helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Spina CMS Changelog
 
+## 2.1 (Unreleased)
+
+* Refactored all CSS with TailwindCSS
+* Refactored all views with ViewComponent
+* Refactored all javascript with Hotwire
+* Added importmap helper `spina_importmap_from`
+
 ## 2.0
 
 ⚠️ _Beware: lots of changes regarding page content. The old page parts are gone in favor of new JSON-based parts. Read the [Upgrading Guide](https://www.spinacms.com/guide/getting-started/upgrading-from-v1) to learn how to upgrade._

--- a/app/assets/javascripts/spina/importmap.json.erb
+++ b/app/assets/javascripts/spina/importmap.json.erb
@@ -1,5 +1,5 @@
 {
   "imports": {
-    <%= importmap_list_with_spina_from Spina::Engine.root.join('app/assets/javascripts/spina/controllers'), Spina::Engine.root.join('app/assets/javascripts/spina/libraries') %>
+    <%= spina_importmap_with_stimulus_from Spina::Engine.root.join('app/assets/javascripts/spina/controllers'), Spina::Engine.root.join('app/assets/javascripts/spina/libraries') %>
   }
 }

--- a/app/helpers/spina/spina_helper.rb
+++ b/app/helpers/spina/spina_helper.rb
@@ -5,9 +5,12 @@ module Spina::SpinaHelper
       javascript_include_tag("stimulus/libraries/es-module-shims", type: "module"),
       tag.script(type: "importmap-shim", src: asset_path("spina/importmap.json")),
       javascript_include_tag("stimulus/libraries/stimulus", type: "module-shim"),
-      javascript_include_tag("stimulus/loaders/autoloader", type: "module-shim"),
       javascript_include_tag("spina/libraries/trix")
     ], "\n"
+  end
+  
+  def autoloader_include_tag
+    javascript_include_tag("stimulus/loaders/autoloader", type: "module-shim")
   end
 
 end

--- a/app/views/layouts/spina/admin/application.html.erb
+++ b/app/views/layouts/spina/admin/application.html.erb
@@ -20,6 +20,9 @@
     <!-- Plugins & Hooks -->
     <%= yield(:head) %>
     <%= render Spina::Hooks::HookComponent.new(partial: "head") %>
+    
+    <!-- Stimulus Autoloader -->
+    <%= autoloader_include_tag %>
   </head>
 
   <body>

--- a/lib/spina/importmap_helper.rb
+++ b/lib/spina/importmap_helper.rb
@@ -1,17 +1,17 @@
 module Spina
   module ImportmapHelper
   
-    def importmap_list_with_spina_from(*paths)
-      [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), importmap_spina_list_from(*paths) ].compact_blank.join(",\n")
+    def spina_importmap_with_stimulus_from(*paths)
+      [ %("stimulus": "#{asset_path("stimulus/libraries/stimulus")}"), spina_importmap_from(*paths) ].reject(&:blank?).join(",\n")
     end
   
-    def importmap_spina_list_from(*paths)
+    def spina_importmap_from(*paths, prepend: "spina")
       Array(paths).flat_map do |path|
         if (absolute_path = absolute_root_of(path)).exist?
           find_javascript_files_in_tree(absolute_path).collect do |filename|
             module_filename = filename.relative_path_from(absolute_path)
             module_name     = importmap_module_name_from(module_filename)
-            module_path     = asset_path('spina/' + absolute_path.basename.join(module_filename).to_s)
+            module_path     = asset_path("#{prepend}/" + absolute_path.basename.join(module_filename).to_s)
       
             %("#{module_name}": "#{module_path}")
           end


### PR DESCRIPTION
Improved to importmap helper by adding support for additional paths. This enables Spina plugins to easily add their own import maps with Stimulus controllers.

An example:

```ruby
# app/assets/javascripts/spina/pro/importmap.json.erb
{
  "imports": {
    <%= spina_importmap_from Spina::Pro::Engine.root.join('app/assets/javascripts/spina/pro/controllers'), prepend: "spina/pro" %>
  }
}
```

Also moved the autoloader to the bottom of the `head` tag so that it loads last.