### PR TITLE
Add position field to sorter

### DIFF
--- a/app/assets/javascripts/spina/controllers/repeater_controller.js
+++ b/app/assets/javascripts/spina/controllers/repeater_controller.js
@@ -21,7 +21,12 @@ export default class extends Controller {
     // Sort the DOM elements containing the repeater fields
     this.panes
       .sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id))
-      .map(node => this.contentTarget.appendChild(node))
+      .map((node, index) => {
+        this.contentTarget.appendChild(node)
+        const positionField = node.querySelector('[data-position]')
+        if (positionField) positionField.value = index
+      })
+
   }
 
   addFields(event) {


### PR DESCRIPTION
### Context

https://github.com/spinacms/spina-case_studies requires a position field for its `CaseStudyPart` content. 

### Changes proposed in this pull request

This PR allows a position field to be included and the controller will set it on sort.
