### PR TITLE
Update ViewComponent and change content slot to label

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       sass-rails
       stimulus-rails
       turbo-rails
-      view_component (= 2.25.1)
+      view_component (~> 2.32)
 
 GEM
   remote: https://rubygems.org/
@@ -99,7 +99,7 @@ GEM
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
-    ffi (1.15.0)
+    ffi (1.15.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.10)
@@ -228,7 +228,7 @@ GEM
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    view_component (2.25.1)
+    view_component (2.32.0)
       activesupport (>= 5.0.0, < 7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)

--- a/app/components/spina/pages/tab_button_component.html.erb
+++ b/app/components/spina/pages/tab_button_component.html.erb
@@ -1,3 +1,3 @@
 <button type="button" class="block px-3 leading-relaxed py-1 hover:text-gray-800 rounded-md text-gray-400 font-medium text-sm flex items-center whitespace-nowrap" data-action="tabs#show" data-tabs-target="button" data-pane-id="<%= @tab_name %>">
-  <%= label %>
+  <%= content %>
 </button>

--- a/app/components/spina/pages/tab_button_component.html.erb
+++ b/app/components/spina/pages/tab_button_component.html.erb
@@ -1,3 +1,3 @@
 <button type="button" class="block px-3 leading-relaxed py-1 hover:text-gray-800 rounded-md text-gray-400 font-medium text-sm flex items-center whitespace-nowrap" data-action="tabs#show" data-tabs-target="button" data-pane-id="<%= @tab_name %>">
-  <%= content %>
+  <%= label %>
 </button>

--- a/app/components/spina/pages/tab_button_component.rb
+++ b/app/components/spina/pages/tab_button_component.rb
@@ -1,17 +1,11 @@
 module Spina
   module Pages
     class TabButtonComponent < ApplicationComponent
-      renders_one :label, "LabelComponent"
 
       def initialize(tab_name:)
         @tab_name = tab_name
       end
 
-      class LabelComponent < ApplicationComponent
-        def call
-          content
-        end
-      end
     end
   end
 end

--- a/app/components/spina/pages/tab_button_component.rb
+++ b/app/components/spina/pages/tab_button_component.rb
@@ -1,14 +1,13 @@
 module Spina
   module Pages
     class TabButtonComponent < ApplicationComponent
-      include ViewComponent::SlotableV2
-      renders_one :content, "ContentComponent"
+      renders_one :label, "LabelComponent"
 
       def initialize(tab_name:)
         @tab_name = tab_name
       end
 
-      class ContentComponent < ApplicationComponent
+      class LabelComponent < ApplicationComponent
         def call
           content
         end

--- a/app/components/spina/user_interface/dropdown_component.rb
+++ b/app/components/spina/user_interface/dropdown_component.rb
@@ -1,8 +1,6 @@
 module Spina
   module UserInterface
-    class DropdownComponent < ApplicationComponent
-      include ViewComponent::SlotableV2
-      
+    class DropdownComponent < ApplicationComponent      
       renders_one :button, "ButtonComponent"
       
       renders_one :menu, "MenuComponent"

--- a/app/components/spina/user_interface/header_component.rb
+++ b/app/components/spina/user_interface/header_component.rb
@@ -1,8 +1,6 @@
 module Spina
   module UserInterface
-    class HeaderComponent < ApplicationComponent
-      include ViewComponent::SlotableV2
-      
+    class HeaderComponent < ApplicationComponent      
       renders_one :actions
       renders_one :navigation
       renders_one :after_breadcrumbs

--- a/app/views/spina/admin/pages/_button_advanced.html.erb
+++ b/app/views/spina/admin/pages/_button_advanced.html.erb
@@ -1,5 +1,5 @@
 <%= render Spina::Pages::TabButtonComponent.new(tab_name: 'advanced')  do |button| %>
-  <% button.content do %>
+  <% button.label do %>
     <%= heroicon('cog', style: :solid, class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
     <%= t("spina.pages.advanced") %>
   <% end %>

--- a/app/views/spina/admin/pages/_button_advanced.html.erb
+++ b/app/views/spina/admin/pages/_button_advanced.html.erb
@@ -1,6 +1,4 @@
-<%= render Spina::Pages::TabButtonComponent.new(tab_name: 'advanced')  do |button| %>
-  <% button.label do %>
-    <%= heroicon('cog', style: :solid, class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
-    <%= t("spina.pages.advanced") %>
-  <% end %>
+<%= render Spina::Pages::TabButtonComponent.new(tab_name: 'advanced') do %>
+  <%= heroicon('cog', style: :solid, class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
+  <%= t("spina.pages.advanced") %>
 <% end %>

--- a/app/views/spina/admin/pages/_button_page_content.html.erb
+++ b/app/views/spina/admin/pages/_button_page_content.html.erb
@@ -1,6 +1,4 @@
-<%= render Spina::Pages::TabButtonComponent.new(tab_name: 'page_content') do |button| %>
-  <% button.label do %>
-    <%= heroicon('document-text', class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
-    <%= t("spina.pages.page_content") %>
-  <% end %>
+<%= render Spina::Pages::TabButtonComponent.new(tab_name: 'page_content') do %>
+  <%= heroicon('document-text', class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
+  <%= t("spina.pages.page_content") %>
 <% end %>

--- a/app/views/spina/admin/pages/_button_page_content.html.erb
+++ b/app/views/spina/admin/pages/_button_page_content.html.erb
@@ -1,5 +1,5 @@
 <%= render Spina::Pages::TabButtonComponent.new(tab_name: 'page_content') do |button| %>
-  <% button.content do %>
+  <% button.label do %>
     <%= heroicon('document-text', class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
     <%= t("spina.pages.page_content") %>
   <% end %>

--- a/app/views/spina/admin/pages/_button_search_engines.html.erb
+++ b/app/views/spina/admin/pages/_button_search_engines.html.erb
@@ -1,7 +1,5 @@
-<%= render Spina::Pages::TabButtonComponent.new(tab_name: 'search_engines') do |button| %>
-  <% button.label do %>
-    <%= heroicon('search', style: :solid, class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
-    <span class="hidden md:inline"><%= t("spina.pages.search_engines") %></span>
-    <span class="md:hidden">SEO</span>
-  <% end %>
+<%= render Spina::Pages::TabButtonComponent.new(tab_name: 'search_engines') do %>
+  <%= heroicon('search', style: :solid, class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
+  <span class="hidden md:inline"><%= t("spina.pages.search_engines") %></span>
+  <span class="md:hidden">SEO</span>
 <% end %>

--- a/app/views/spina/admin/pages/_button_search_engines.html.erb
+++ b/app/views/spina/admin/pages/_button_search_engines.html.erb
@@ -1,5 +1,5 @@
 <%= render Spina::Pages::TabButtonComponent.new(tab_name: 'search_engines') do |button| %>
-  <% button.content do %>
+  <% button.label do %>
     <%= heroicon('search', style: :solid, class: 'w-4 h-4 mr-1 -ml-1 opacity-75') %>
     <span class="hidden md:inline"><%= t("spina.pages.search_engines") %></span>
     <span class="md:hidden">SEO</span>

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mobility', '1.1.2'
   gem.add_dependency 'rack-rewrite', '>= 1.5.0'
   gem.add_dependency 'attr_json'
-  gem.add_dependency 'view_component', '2.25.1'
+  gem.add_dependency 'view_component', '~> 2.32'
   gem.add_dependency 'turbo-rails'
   gem.add_dependency 'stimulus-rails'
 end


### PR DESCRIPTION
Updated ViewComponent to 2.32. Removed `include ViewComponent::SlotableV2` because it's not required anymore.

The new `TabButtonComponent` that was introduced in #707 used a slot name `content` which is not supported anymore, so I changed that to `label`.