### PR TITLE
Refactor TabLinkComponent

### DIFF
--- a/app/components/spina/user_interface/tab_link_component.html.erb
+++ b/app/components/spina/user_interface/tab_link_component.html.erb
@@ -1,3 +1,3 @@
-<%= link_to @path, class: "block px-3 leading-relaxed py-1 hover:text-gray-800 rounded-md text-gray-400 font-medium text-sm flex items-center #{css_classes}" do %>
-  <%= @label %>
+<%= link_to @url, class: "block px-3 leading-relaxed py-1 hover:text-gray-800 rounded-md text-gray-400 font-medium text-sm flex items-center #{css_classes}" do %>
+  <%= content %>
 <% end %>

--- a/app/components/spina/user_interface/tab_link_component.html.erb
+++ b/app/components/spina/user_interface/tab_link_component.html.erb
@@ -1,3 +1,3 @@
 <%= link_to @url, class: "block px-3 leading-relaxed py-1 hover:text-gray-800 rounded-md text-gray-400 font-medium text-sm flex items-center #{css_classes}" do %>
-  <%= content %>
+  <%= content || @name %>
 <% end %>

--- a/app/components/spina/user_interface/tab_link_component.rb
+++ b/app/components/spina/user_interface/tab_link_component.rb
@@ -2,10 +2,9 @@ module Spina
   module UserInterface
     class TabLinkComponent < ApplicationComponent
       
-      def initialize(label, path, active: false)
-        @label = label
-        @path = path
-        @active = active
+      def initialize(url, options = {})
+        @url = url
+        @active = options[:active]
       end
       
       def css_classes

--- a/app/components/spina/user_interface/tab_link_component.rb
+++ b/app/components/spina/user_interface/tab_link_component.rb
@@ -2,9 +2,11 @@ module Spina
   module UserInterface
     class TabLinkComponent < ApplicationComponent
       
-      def initialize(url, options = {})
+      def initialize(name = nil, url = nil, active: false)
+        url = name if url.nil?
         @url = url
-        @active = options[:active]
+        @name = name
+        @active = active
       end
       
       def css_classes

--- a/app/views/spina/admin/attachments/index.html.erb
+++ b/app/views/spina/admin/attachments/index.html.erb
@@ -13,8 +13,15 @@
   <% header.navigation do %>
     <nav class="-mb-3 mt-4">
       <ul class="inline-flex w-auto rounded-md bg-white">
-        <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('photograph', style: :solid, class: 'w-5 h\-5 mr-2 -ml-1')} #{t('spina.media_library.images')}".html_safe, spina.admin_images_path) %>
-        <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('document', style: :solid, class: 'w-5 h-5 mr-2 -ml-1')} #{t('spina.media_library.attachments')}".html_safe, spina.admin_attachments_path, active: true) %>
+        <%= render Spina::UserInterface::TabLinkComponent.new(spina.admin_images_path) do %>
+          <%= heroicon('photograph', style: :solid, class: 'w-5 h-5 mr-2 -ml-1') %>
+          <%=t 'spina.media_library.images' %>
+        <% end %>
+        
+        <%= render Spina::UserInterface::TabLinkComponent.new(spina.admin_attachments_path, active: true) do %>
+          <%= heroicon('document', style: :solid, class: 'w-5 h-5 mr-2 -ml-1') %>
+          <%=t 'spina.media_library.attachments' %>
+        <% end %>
       </ul>
     </nav>
   <% end %>

--- a/app/views/spina/admin/images/index.html.erb
+++ b/app/views/spina/admin/images/index.html.erb
@@ -27,8 +27,15 @@
   <% header.navigation do %>
     <nav class="-mb-3 mt-4">
       <ul class="inline-flex w-auto rounded-md bg-white">
-        <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('photograph', style: :solid, class: 'w-5 h-5 mr-2 -ml-1')} #{t('spina.media_library.images')}".html_safe, spina.admin_images_path, active: true) %>
-        <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('document', style: :solid, class: 'w-5 h-5 mr-2 -ml-1')} #{t('spina.media_library.attachments')}".html_safe, spina.admin_attachments_path) %>
+        <%= render Spina::UserInterface::TabLinkComponent.new(spina.admin_images_path, active: true) do %>
+          <%= heroicon('photograph', style: :solid, class: 'w-5 h-5 mr-2 -ml-1') %>
+          <%=t 'spina.media_library.images' %>
+        <% end %>
+        
+        <%= render Spina::UserInterface::TabLinkComponent.new(spina.admin_attachments_path) do %>
+          <%= heroicon('document', style: :solid, class: 'w-5 h-5 mr-2 -ml-1') %>
+          <%=t 'spina.media_library.attachments' %>
+        <% end %>
       </ul>
     </nav>
   <% end %>

--- a/app/views/spina/admin/navigations/edit.html.erb
+++ b/app/views/spina/admin/navigations/edit.html.erb
@@ -3,7 +3,10 @@
     <nav class="-mb-3 mt-4">
       <ul class="inline-flex w-auto rounded-md bg-white">
         <% @navigations.each do |navigation| %>
-          <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('menu-alt-2', style: :solid, class: 'w-3 h-3 mr-1')} #{navigation.label}".html_safe, spina.edit_admin_navigation_path(navigation), active: @navigation == navigation) %>
+          <%= render Spina::UserInterface::TabLinkComponent.new(spina.edit_admin_navigation_path(navigation), active: @navigation == navigation) do %>
+            <%= heroicon('menu-alt-2', style: :solid, class: 'w-3 h-3 mr-1') %>
+            <%= navigation.label %>
+          <% end %>
         <% end %>
       </ul>
     </nav>

--- a/app/views/spina/admin/pages/index.html.erb
+++ b/app/views/spina/admin/pages/index.html.erb
@@ -35,10 +35,18 @@
   <% header.navigation do %>
     <nav class="-mb-1 md:-mb-3 mt-4">
       <ul class="inline-flex w-auto rounded-md bg-white">
-        <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('collection', style: :solid, class: 'h-4 w-4 mr-1 -ml-1 opacity-75')} #{t('spina.website.main')}".html_safe, spina.admin_pages_path, active: @resource.nil?) %>
+        <%= render Spina::UserInterface::TabLinkComponent.new(spina.admin_pages_path, active: @resource.nil?) do %>
+          <%= heroicon('collection', style: :solid, class: "h-4 w-4 mr-1 -ml-1 opacity-75") %>
+          <%=t 'spina.website.main' %>
+        <% end %>
         
         <% Spina::Resource.order(:name).each do |resource| %>
-          <%= render Spina::UserInterface::TabLinkComponent.new("#{heroicon('collection', class: 'h-4 w-4 mr-1 -ml-1 opacity-75')} #{resource.label}".html_safe, spina.admin_pages_path(resource_id: resource.id), active: @resource == resource) %>
+        
+          <%= render Spina::UserInterface::TabLinkComponent.new(spina.admin_pages_path(resource_id: resource.id), active: @resource == resource) do %>
+            <%= heroicon('collection', class: 'h-4 w-4 mr-1 -ml-1 opacity-75') %>
+            <%= resource.label %>
+          <% end %>
+          
         <% end %>
       </ul>
     </nav>


### PR DESCRIPTION
You can pass a block to the `TabLinkComponent` to render the label of tab links, just like `TabButtonComponent`.

There's two ways to render a `TabLinkComponent` now:

```ruby
render Spina::UserInterface::TabLinkComponent.new("My link", "#")
```

or 

```ruby
render Spina::UserInterface::TabLinkComponent.new("#") do 
  "My link!"
end