### PR TITLE
Only create rewrite_rule on update

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -35,7 +35,7 @@ module Spina
     after_save :touch_navigations
 
     # Create a 301 redirect if materialized_path changed
-    after_save :rewrite_rule
+    after_update :rewrite_rule
 
     before_validation :set_materialized_path
     validates :title, presence: true


### PR DESCRIPTION
Spina currently creates rewrite rules even when pages are first created. That's not ideal because it creates a rewrite rule with `nil` as the `old_path`. 

This PR moves the AR callback to `after_update`.