### PR TITLE
Use the slots API because with_content_areas is deprecated

### DIFF
--- a/app/components/spina/main_navigation/sub_nav_component.rb
+++ b/app/components/spina/main_navigation/sub_nav_component.rb
@@ -1,7 +1,8 @@
 module Spina
   module MainNavigation
-    class SubNavComponent < ApplicationComponent
-      with_content_areas :icon, :links
+    class SubNavComponent < ApplicationComponent      
+      renders_one :icon
+      renders_one :links
       
       def initialize(name = :content)
         @name = name

--- a/app/views/spina/admin/shared/_navigation.html.erb
+++ b/app/views/spina/admin/shared/_navigation.html.erb
@@ -3,7 +3,7 @@
 
     <ul class="flex md:flex-col">
       <%= render Spina::MainNavigation::SubNavComponent.new(:content) do |nav| %>
-        <% nav.with(:icon) do %>
+        <% nav.icon do %>
           <%= heroicon('document-text', style: :solid, class: 'hidden md:block w-8 h-8 text-white md:mr-3') %>
           <%= heroicon('menu', style: :solid, class: 'md:hidden w-8 h-8 text-white md:mr-3') %>
           
@@ -12,7 +12,7 @@
           </div>
         <% end %>
 
-        <% nav.with(:links) do %>
+        <% nav.links do %>
         
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.pages'), spina.admin_pages_path, active: controller_name.in?(%w(pages resources)) %>
           
@@ -29,7 +29,7 @@
       <%= render Spina::Hooks::HookComponent.new(partial: "primary_navigation") %>
 
       <%= render Spina::MainNavigation::SubNavComponent.new(:settings) do |nav| %>
-        <% nav.with(:icon) do %>
+        <% nav.icon do %>
           <%= heroicon('cog', style: :solid, class: 'w-8 h-8 text-white md:mr-3') %>
           
           <div class="text-white font-semibold hidden md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all" data-navigation-target="label">
@@ -37,7 +37,7 @@
           </div>
         <% end %>
 
-        <% nav.with(:links) do %>
+        <% nav.links do %>
           <%= render Spina::MainNavigation::LinkComponent.new("General", spina.edit_admin_account_path, active: controller_name == "accounts") %>
           <%= render Spina::MainNavigation::LinkComponent.new(t('spina.website.theme'), spina.edit_admin_theme_path, active: controller_name == "theme") %>
           <%= render Spina::MainNavigation::LinkComponent.new("Users", spina.admin_users_path, active: controller_name == "users") %>


### PR DESCRIPTION
`with_content_areas` is deprecated and will be removed in ViewComponent 3.0. I replaced the one instance where we still used it with the new Slots API.