### PR TITLE
Hide user management buttons for normal users

### DIFF
--- a/app/views/spina/admin/users/_user.html.erb
+++ b/app/views/spina/admin/users/_user.html.erb
@@ -25,10 +25,12 @@
       <%=t 'spina.users.never_logged_in' %>
     <% end %>
   </div>
-  
-  <div>
-    <%= link_to spina.edit_admin_user_path(user), class: "btn btn-default px-3" do %>
-      <%= heroicon('pencil', style: :solid, class: 'w-4 h-4') %>
-    <% end %>
-  </div>
+
+  <% if current_spina_user.admin? %>
+    <div>
+      <%= link_to spina.edit_admin_user_path(user), class: "btn btn-default px-3" do %>
+        <%= heroicon('pencil', style: :solid, class: 'w-4 h-4') %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/spina/admin/users/index.html.erb
+++ b/app/views/spina/admin/users/index.html.erb
@@ -1,7 +1,9 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
   <% header.after_breadcrumbs do %>
-    <%= link_to spina.new_admin_user_path, class: 'btn btn-default h-8 px-2 ml-3' do %>
-      <%= heroicon('plus', style: :solid, class: 'w-6 h-6') %>
+    <% if current_spina_user.admin? %>
+      <%= link_to spina.new_admin_user_path, class: 'btn btn-default h-8 px-2 ml-3' do %>
+        <%= heroicon('plus', style: :solid, class: 'w-6 h-6') %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
### Context
Buttons for adding and editing users are not hidden for normal users. Since only admins can manage users, this leads to an error.

### Changes proposed in this pull request
Check if the current user is admin before displaying user management buttons.
