### PR TITLE
Save all pages after updating resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Refactored all views with ViewComponent
 * Refactored all javascript with Hotwire
 * Added importmap helper `spina_importmap_from`
+* Added background job to save resource pages in bulk
 
 ## 2.0
 

--- a/app/jobs/spina/application_job.rb
+++ b/app/jobs/spina/application_job.rb
@@ -1,0 +1,9 @@
+module Spina
+  class ApplicationJob < ActiveJob::Base
+    # Automatically retry jobs that encountered a deadlock
+    # retry_on ActiveRecord::Deadlocked
+
+    # Most jobs are safe to ignore if the underlying records are no longer available
+    # discard_on ActiveJob::DeserializationError
+  end
+end

--- a/app/jobs/spina/application_job.rb
+++ b/app/jobs/spina/application_job.rb
@@ -1,9 +1,4 @@
 module Spina
   class ApplicationJob < ActiveJob::Base
-    # Automatically retry jobs that encountered a deadlock
-    # retry_on ActiveRecord::Deadlocked
-
-    # Most jobs are safe to ignore if the underlying records are no longer available
-    # discard_on ActiveJob::DeserializationError
   end
 end

--- a/app/jobs/spina/page_update_job.rb
+++ b/app/jobs/spina/page_update_job.rb
@@ -1,0 +1,9 @@
+module Spina
+  class PageUpdateJob < ApplicationJob
+    queue_as :default
+
+    def perform(resource_id)
+      Spina::Page.where(resource_id: resource_id).each(&:save)
+    end
+  end
+end

--- a/app/jobs/spina/page_update_job.rb
+++ b/app/jobs/spina/page_update_job.rb
@@ -1,9 +1,0 @@
-module Spina
-  class PageUpdateJob < ApplicationJob
-    queue_as :default
-
-    def perform(resource_id)
-      Spina::Page.where(resource_id: resource_id).each(&:save)
-    end
-  end
-end

--- a/app/jobs/spina/resource_pages_update_job.rb
+++ b/app/jobs/spina/resource_pages_update_job.rb
@@ -1,0 +1,11 @@
+module Spina
+  class ResourcePagesUpdateJob < ApplicationJob
+    queue_as { Spina.config.queues[:page_updates] }
+  
+    def perform(resource_id)
+      Page.where(resource_id: resource_id).find_each(batch_size: 100) do |page|
+        page.save
+      end
+    end
+  end
+end

--- a/app/jobs/spina/resource_pages_update_job.rb
+++ b/app/jobs/spina/resource_pages_update_job.rb
@@ -3,7 +3,7 @@ module Spina
     queue_as { Spina.config.queues[:page_updates] }
   
     def perform(resource_id)
-      Page.where(resource_id: resource_id).find_each(batch_size: 100) do |page|
+      Page.where(resource_id: resource_id).roots.find_each(batch_size: 100) do |page|
         page.save
       end
     end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -4,7 +4,7 @@ module Spina
 
     has_many :pages, dependent: :restrict_with_exception
 
-    after_save :save_pages
+    after_commit :update_resource_pages, on: [:update]
 
     translates :slug, backend: :jsonb
 
@@ -19,8 +19,10 @@ module Spina
       end
     end
 
-    def save_pages
-      PageUpdateJob.perform_later id
+    def update_resource_pages
+      if previous_changes[:slug]
+        ResourcePagesUpdateJob.perform_later(id)
+      end
     end
 
   end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -4,6 +4,8 @@ module Spina
 
     has_many :pages, dependent: :restrict_with_exception
 
+    after_save :save_pages
+
     translates :slug, backend: :jsonb
 
     def pages
@@ -16,6 +18,11 @@ module Spina
         super.order(:position)
       end
     end
+
+    def save_pages
+      pages.each(&:save)
+    end
+
     
   end
 end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -20,9 +20,8 @@ module Spina
     end
 
     def save_pages
-      pages.each(&:save)
+      PageUpdateJob.perform_later id
     end
 
-    
   end
 end

--- a/docs/v2/themes/6_resources.md
+++ b/docs/v2/themes/6_resources.md
@@ -33,3 +33,7 @@ Every resource can have the following attributes:
 - parent_page_id
 
 When defining a parent page, all pages within that resource will be scoped to that parent page. This means that all generated URL's will be prefixed with the parent page's URL. An example: you can create a regular page called `blog` and have a resource called `blogposts`. Your blog view template could then list all pages that are inside the blog resource. In Spina you would have a nice separate menu called "Blogposts" where you can easily manage a list of blogposts. 
+
+**Updating resources and page slugs/paths**
+
+After updating a resource and changing it's slug, a background job is created. This background job saves all pages inside that resource, triggering a callback that sets new materialized paths. Be sure to setup a background worker (using Sidekiq for instance) in your production environment to perform these tasks.

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -15,6 +15,12 @@ Spina.configure do |config|
   # The parent controller all frontend Spina controllers inherit from
   # Defaults to ApplicationController
   # config.frontend_parent_controller = "ApplicationController"
+  
+  # Background jobs
+  # ===============
+  # 
+  # By default, all background jobs are queued as :default
+  # config.queues.page_updates = :default
 
   # Confetti
   # ===============

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -22,7 +22,8 @@ module Spina
                   :locales, 
                   :embedded_image_size,
                   :party_pooper,
-                  :tailwind_purge_content
+                  :tailwind_purge_content,
+                  :queues
 
   # Specify a backend path. Defaults to /admin.
   self.backend_path = 'admin'
@@ -36,6 +37,9 @@ module Spina
   self.max_page_depth = 5
 
   self.locales = [I18n.default_locale]
+  
+  # Queues
+  self.queues = ActiveSupport::InheritableOptions.new
   
   # Don't like confetti?
   self.party_pooper = false

--- a/test/dummy/config/initializers/spina.rb
+++ b/test/dummy/config/initializers/spina.rb
@@ -15,6 +15,12 @@ Spina.configure do |config|
   # The parent controller all frontend Spina controllers inherit from
   # Defaults to ApplicationController
   # config.frontend_parent_controller = "ApplicationController"
+  
+  # Background jobs
+  # ===============
+  # 
+  # By default, all background jobs are queued as :default
+  # config.queues.page_updates = :default
 
   # Pages Options
   # ===============

--- a/test/integration/spina/admin/resources_test.rb
+++ b/test/integration/spina/admin/resources_test.rb
@@ -43,6 +43,12 @@ module Spina
         assert_select 'div', text: /.*Top\sBreweries.*/
       end
 
+      test "update slug enqueues a bg job" do
+        put "/admin/resources/#{@breweries.id}", params: {resource: {slug: "new-slug"}}
+        follow_redirect!
+        assert_enqueued_jobs 1, only: Spina::ResourcePagesUpdateJob
+      end
+
     end
   end
 end


### PR DESCRIPTION
### Context
Fixes #714 

### Changes proposed in this pull request
Update all pages of a resource when it is saved to make sure the materialized path is updated.