### PR TITLE
Hotfix for Turbo beta6 - Fixes #723

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       rails (>= 6.0.0)
     thor (1.1.0)
     tilt (2.0.10)
-    turbo-rails (0.5.9)
+    turbo-rails (0.5.10)
       rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/app/assets/javascripts/spina/controllers/modal_controller.js
+++ b/app/assets/javascripts/spina/controllers/modal_controller.js
@@ -8,10 +8,22 @@ export default class extends Controller {
 
   close() {
     this.element.remove()
+    this.resetTurboFrame() // Bugfix
   }
   
   escClose(event) {
     if (event.key === 'Escape') this.close()
+  }
+  
+  // Reset Turbo Frame
+  // This is a bugfix for a bug introduced in turbo 7.0.0-beta.6
+  // https://github.com/hotwired/turbo/issues/249
+  resetTurboFrame() {
+    this.modalTurboFrame.src = ""
+  }
+  
+  get modalTurboFrame() {
+    return document.querySelector(`turbo-frame[id="modal"]`)
   }
 
 }

--- a/app/views/spina/admin/images/_image.html.erb
+++ b/app/views/spina/admin/images/_image.html.erb
@@ -8,7 +8,7 @@
       <span class="truncate"><%= image.file.filename %></span>
     
       <div class="absolute h-full opacity-0 group-hover:opacity-100 flex items-center right-0 pr-3 top-0">
-        <%= link_to spina.edit_admin_image_path(image), class: "btn btn-default h-7 px-2 mr-2 text-xs" do %>
+        <%= link_to spina.edit_admin_image_path(image, t: Time.now.to_i), class: "btn btn-default h-7 px-2 mr-2 text-xs" do %>
           <%= heroicon('pencil', style: :solid, class: 'w-4 h-4 mr-1 text-gray-600') %>
           <%=t 'spina.ui.rename' %>
         <% end %>


### PR DESCRIPTION
Added a hotfix that resets the `src` on the modal turbo frame when closing a modal. 

Related issue: https://github.com/hotwired/turbo/issues/249