### PR TITLE
Fixes pages custom path if Spine Engine route is different than default

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -55,6 +55,10 @@ module Spina
     def slug
       url_title&.parameterize
     end
+
+    def url
+      [engine_path, materialized_path].join
+    end
     
     def homepage?
       name == 'homepage'
@@ -102,6 +106,10 @@ module Spina
     end
 
     private
+
+      def engine_path
+        Spina::Engine.routes.url_helpers.root_path.gsub(/\/$/, '')
+      end
 
       def set_resource_from_parent
         self.resource_id = parent.resource_id

--- a/app/presenters/spina/menu_presenter.rb
+++ b/app/presenters/spina/menu_presenter.rb
@@ -55,7 +55,7 @@ module Spina
 
         content_tag(list_item_tag, class: list_item_css, data: {page_id: item.page_id, draft: (true if item.draft?) }) do
           buffer = ActiveSupport::SafeBuffer.new
-          buffer << link_to(item.menu_title, item.materialized_path, class: link_tag_css)
+          buffer << link_to(item.menu_title, item.url, class: link_tag_css)
           buffer << render_items(children) if render_children?(item) && children.any?
           buffer
         end

--- a/app/views/spina/admin/pages/_form.html.erb
+++ b/app/views/spina/admin/pages/_form.html.erb
@@ -4,7 +4,7 @@
       <% if @page.draft? %>
         <span class="text-gray-400 ml-2 text-sm">(<%= Spina::Page.human_attribute_name(:draft) %>)</span>
       <% end %>
-      <%= link_to @page.materialized_path, class: 'px-3 py-2 flex items-center text-gray-400 hover:text-gray-700', target: :blank, data: {turbo: false} do %>
+      <%= link_to @page.url, class: 'px-3 py-2 flex items-center text-gray-400 hover:text-gray-700', target: :blank, data: {turbo: false} do %>
         <%= heroicon("external-link", style: :solid, class: "w-4 h-4") %>
       <% end %>
     <% end %>

--- a/app/views/spina/admin/pages/_form_search_engines.html.erb
+++ b/app/views/spina/admin/pages/_form_search_engines.html.erb
@@ -39,7 +39,7 @@
 
     <div class="col-span-2">
       <%= f.text_field :url_title, class: "form-input block w-full sm:text-sm sm:leading-5", placeholder: f.object.slug || Spina::Page.human_attribute_name(:url_title_placeholder), value: f.object.url_title(fallback: false, default: nil)&.parameterize %>
-      <div class="text-sm text-gray-400 mt-1"><%=t 'spina.pages.path' %> <%= @page.materialized_path %></div>
+      <div class="text-sm text-gray-400 mt-1"><%=t 'spina.pages.path' %> <%= @page.url %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Context

I want to change Spina root url since I'm using it in a existing project. I changed `routes.rb` configuration with:

`mount Spina::Engine => '/blog'`

After this change Pages urls are broken since they are missing root path (`/blog`)

### Changes proposed in this pull request

Add a Page method (`url`) to include Spina::Engine root url. This change affects:

1. `Spina::MenuPresenter`
2. Admin pages views

### Guidance to review

Change `routes.rb` configuration and check if all Pages urls are working correctly

(This is my first day using Spina. Sorry if this solution is not the best)