### PR TITLE
Stimulus controllers for attachment forms - Fixes #747 and #746

### DIFF
--- a/app/assets/javascripts/spina/controllers/attachment_picker_controller.js
+++ b/app/assets/javascripts/spina/controllers/attachment_picker_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static get targets() {
+    return [ "signedBlobId", "filename" ]
+  }
+
+  pick(event) {
+    let select = event.currentTarget
+    let option = select.options[select.selectedIndex]
+    this.signedBlobIdTarget.value = option.dataset.signedBlobId || ""
+    this.filenameTarget.value = option.dataset.filename || ""
+  }
+  
+}

--- a/app/models/spina/attachment.rb
+++ b/app/models/spina/attachment.rb
@@ -13,6 +13,10 @@ module Spina
     def content
       file if file.attached?
     end
+    
+    def present?
+      signed_blob_id.present?
+    end
 
     alias_method :old_update, :update
     def update(attributes)

--- a/app/views/spina/admin/attachments/index.html.erb
+++ b/app/views/spina/admin/attachments/index.html.erb
@@ -1,6 +1,6 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
   <% header.actions do %>
-    <%= form_with model: [:admin, Spina::Attachment.new], url: spina.admin_attachments_path, data: {controller: "form loading-button", loading_message: t('spina.media_library.uploading'), action: "turbo-submit-end->loading-button#doneLoading"} do |f| %>
+    <%= form_with model: [:admin, Spina::Attachment.new], url: spina.admin_attachments_path, data: {controller: "form loading-button", loading_message: t('spina.media_library.uploading'), action: "turbo:submit-end->loading-button#doneLoading"} do |f| %>
     
       <%= f.file_field :files, multiple: true, id: "new_attachment_file_field", class: 'hidden', data: {action: "loading-button#loading form#requestSubmit"} %>
       

--- a/app/views/spina/admin/parts/attachments/_form.html.erb
+++ b/app/views/spina/admin/parts/attachments/_form.html.erb
@@ -1,8 +1,8 @@
-<div class="mt-6">
+<div class="mt-6" data-controller="attachment-picker">
   <label for="price" class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
 
   <%= f.hidden_field :signed_blob_id, data: {attachment_picker_target: 'signedBlobId'} %>
   <%= f.hidden_field :filename, data: {attachment_picker_target: 'filename'} %>
 
-  <%= f.select :attachment_id, Spina::Attachment.sorted.map{|attachment| [attachment.file&.filename, attachment.id, data: {signed_blob_id: attachment.file&.blob&.signed_id, filename: attachment.file&.filename}]}, {include_blank: t("spina.attachments.choose_attachment")}, {class: "form-select"} %>
+  <%= f.select :attachment_id, Spina::Attachment.sorted.map{|attachment| [attachment.file&.filename, attachment.id, data: {signed_blob_id: attachment.file&.blob&.signed_id, filename: attachment.file&.filename}]}, {include_blank: t("spina.attachments.choose_attachment")}, {class: "form-select", data: {action: "attachment-picker#pick"}} %>
 </div>

--- a/config/locales/TH.yml
+++ b/config/locales/TH.yml
@@ -108,6 +108,7 @@ th:
       delete_confirmation_html: 
       insert: แทรกเอกสาร
       insert_multiple: แทรกเอกสาร
+      upload: 
     cancel: ยกเลิก
     choose_from_library: เลือกจากไลบารี
     close: ปิด

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -108,6 +108,7 @@ bg:
       delete_confirmation_html: 
       insert: Добавете документ
       insert_multiple: Добавете документи
+      upload: 
     cancel: Спри
     choose_from_library: Избери от библиотеката
     close: Затвори

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -108,6 +108,7 @@ de:
       delete_confirmation_html: 
       insert: Dokument einfügen
       insert_multiple: Dokumente einfügen
+      upload: 
     cancel: Abbrechen
     choose_from_library: Wähle aus Bibliothek
     close: Schließen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
       delete_confirmation_html: Are you sure? This attachment <span class='font-semibold'>might</span> be in use on a page.
       insert: Insert document
       insert_multiple: Insert documents
+      upload: Upload files
     cancel: Cancel
     choose_from_library: Choose from library
     close: Close

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -105,7 +105,7 @@ es:
     ago: atrás
     attachments:
       choose_attachment: Elegir documentos
-      delete_confirmation_html: "¿Estás seguro? El documento <span class='font-semibold'>podría estar en uso</span> en otra página."
+      delete_confirmation_html: ¿Estás seguro? El documento <span class='font-semibold'>podría estar en uso</span> en otra página.
       insert: Insertar documento
       insert_multiple: Insertar documentos
       upload: 
@@ -113,7 +113,7 @@ es:
     choose_from_library: Elegir de la biblioteca
     close: Cerrar
     delete: Eliminar
-    delete_confirmation: "¿Estás seguro que quieres eliminar <strong>%{subject}</strong>?"
+    delete_confirmation: ¿Estás seguro que quieres eliminar <strong>%{subject}</strong>?
     edit: Editar
     edit_website: Editar sitio
     forgot_password:
@@ -132,7 +132,7 @@ es:
       choose_images: Elegir imágenes
       confirm_selection: Confimar selección
       delete: Eliminar
-      delete_confirmation_html: "¿Estás seguro que quieres eliminar esta <strong>imagen</strong>?"
+      delete_confirmation_html: ¿Estás seguro que quieres eliminar esta <strong>imagen</strong>?
       delete_folder: Eliminar carpeta
       done_organizing: Terminar el ordenamiento
       insert_image: Insertar imagen
@@ -181,7 +181,7 @@ es:
         one: Una imagen
         other: "%{count} imágenes"
       insert: Insertar imagen
-      media_folder_delete_confirmation_html: "¿Estás seguro? Las imágenes <strong>no</strong> serán eliminadas."
+      media_folder_delete_confirmation_html: ¿Estás seguro? Las imágenes <strong>no</strong> serán eliminadas.
       no_folder: No hay folders
       photos: Imágenes
       rename_folder: Renombrar folder
@@ -196,7 +196,7 @@ es:
       add_sub_item: Agregar sub-elemento
       choose_page: Elige la página
       delete_item: Eliminar elemento
-      delete_item_confirmation_html: "¿Estás seguro que quieres <span class='font-semibold'>eliminar</span>? este elemento?"
+      delete_item_confirmation_html: ¿Estás seguro que quieres <span class='font-semibold'>eliminar</span>? este elemento?
       description: Agrega u ordena los elementos a tu preferencia. También puedes agregar elementos anidados al menú (opcional).
       navigations: Navegación
       no_navigations: Este sitio no cuenta con navegación. Puedes configurarlo en las opciones de tu tema.
@@ -215,19 +215,19 @@ es:
       cannot_be_deleted: No se puede eliminar la página
       change_order: Cambiar orden
       change_view_template: Cambiar plantilla
-      change_view_template_confirmation: "¿Estás seguro que quieres cambiar la plantilla de tu página? El contenidod el página que no pertenezca a la plantilla será eliminada."
+      change_view_template_confirmation: ¿Estás seguro que quieres cambiar la plantilla de tu página? El contenidod el página que no pertenezca a la plantilla será eliminada.
       concept: borrador
       create: Crear página
       create_page: Nuevo %{template}
       delete: Eliminar página
-      delete_confirmation: "¿Estás seguro que quieres eliminar la página <strong>%{subject}</strong>?"
+      delete_confirmation: ¿Estás seguro que quieres eliminar la página <strong>%{subject}</strong>?
       deleted: Página eliminada
       done_changing_order: Ordenamiento finalizado
       edit_translation: Editar traducción al %{language}
       invisible_to_search_engines: Tu sitio es invisible para los motores de búsqueda
       invisible_to_search_engines_description: Ingresa a preferencias para activar los motores de búsqueda.
       main_collection: Colección principal
-      materialize_path_confirmation: "¿Estás seguro de que quieres reconstruir la ruta para esta página?"
+      materialize_path_confirmation: ¿Estás seguro de que quieres reconstruir la ruta para esta página?
       missing_translations: Faltan traducciónes
       move_page: Mover página
       moved: Página movida
@@ -259,7 +259,7 @@ es:
       cannot_be_created: 'Tu imagen no puede ser procesada:'
       choose_images: Seleccionar imágenes
       delete: Borrar
-      delete_confirmation: "¿Estás seguro que deseas eliminar ésta <strong>imagen</strong>?"
+      delete_confirmation: ¿Estás seguro que deseas eliminar ésta <strong>imagen</strong>?
       delete_folder: Borrar carpeta
       done_organizing: Terminar el ordenamiento
       insert_photo: Insertar imagen

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -49,9 +49,9 @@ es:
         menu_title: Título de navegación
         menu_title_placeholder: Deja en blanco para usar el título de la página
         no_parent: No página padre
-        resource: 
+        resource: Recurso
         seo_title: SEO <title>
-        seo_title_description: 
+        seo_title_description: SEO <description>
         seo_title_placeholder: Este título es usado en <title>-tag
         show_in_menu: Mostrar en navegación
         show_in_menu_description: Si se desactiva esta página no será mostrada en tu navegación
@@ -59,15 +59,15 @@ es:
         skip_to_first_child_description: Reenviar a la primera página hija
         title: Título
         title_placeholder: Título de la página
-        url_title: 
-        url_title_description: 
-        url_title_placeholder: 
+        url_title: Sobreescribir slug
+        url_title_description: Opcional
+        url_title_placeholder: Slug
         view_template: Plantilla de página
       spina/resource:
         label: Etiqueta
         order_by: Ordenar por
         parent_page: Página padre
-        view_template: 
+        view_template: Plantilla
       spina/user:
         admin: Administrador
         admin_description: Los administradores pueden crear usuarios
@@ -96,18 +96,19 @@ es:
         other: Usuarios
   spina:
     accounts:
-      contact_details: 
-      contact_details_description: 
-      couldnt_be_saved: 
-      name_description: 
-      save: 
-      saved: 
+      contact_details: Detalles de contacto
+      contact_details_description: Correo electrónico y teléfono
+      couldnt_be_saved: La cuenta no puede ser guardada
+      name_description: El nombre de tu sitio web
+      save: Guardar cuenta
+      saved: Cuenta guardada
     ago: atrás
     attachments:
-      choose_attachment: 
-      delete_confirmation_html: 
+      choose_attachment: Elegir documentos
+      delete_confirmation_html: "¿Estás seguro? El documento <span class='font-semibold'>podría estar en uso</span> en otra página."
       insert: Insertar documento
       insert_multiple: Insertar documentos
+      upload: 
     cancel: Cancelar
     choose_from_library: Elegir de la biblioteca
     close: Cerrar
@@ -124,17 +125,17 @@ es:
       success: Puede utilizar su nueva contraseña
       unknown_user: Este usuario no existe
     images:
-      all_images: 
+      all_images: Todas las imágenes
       back: Regresar
       cannot_be_created: No puede ser creada
       choose_image: Elegir imagen
       choose_images: Elegir imágenes
-      confirm_selection: 
+      confirm_selection: Confimar selección
       delete: Borrar
       delete_confirmation_html: Esta seguro que desea borrar esta <strong>imagen</strong>?
       delete_folder: Borrar carpeta
-      done_organizing: 
-      insert_image: 
+      done_organizing: Terminar el ordenamiento
+      insert_image: Insertar imagen
       insert_photo: Insertar foto
       insert_photos: Insertar fotos
       link: Enlace
@@ -144,113 +145,115 @@ es:
       upload: Subir imáneges
       upload_image: Subir imagen
     languages:
-      bg: 
+      bg: Búlgaro
       de: Alemán
       en: Inglés
       es: Español
       fr: Francés
-      id: 
+      id: Indonesio
       it: Italiano
       nl: Holandés
       pl: Polaco
-      pt-BR: 
-      ro: 
-      ru: 
-      sv: 
-      th: 
-      tr: 
-      zh-CN: 
+      pt-BR: Portugués brasileño
+      ro: Rumano
+      ru: Ruso
+      sv: Sueco
+      th: Tailandés
+      tr: Turco
+      zh-CN: Chino
     layout:
-      couldnt_be_saved: 
-      layout: 
-      no_layout_parts: 
-      save: 
-      saved: 
+      couldnt_be_saved: El diseño no se puede guardar
+      layout: Diseño
+      no_layout_parts: No hay partes del diseño disponibles
+      save: Guardar diseño
+      saved: Diseño guardado
     login: Ingresar
     logout: Cerrar sesión
     main_menu: Menú principal
     media_library:
-      add_folder: 
-      add_image: 
+      add_folder: Agregar folder
+      add_image: Agregar imagen
       attachments: Documentos
-      back_to_all: 
-      filename: 
+      back_to_all: Regresar
+      filename: Nombre del archivo
       images: Imágenes
-      images_count: 
-      insert: 
-      media_folder_delete_confirmation_html: 
-      no_folder: 
+      images_count:
+        one: Una imagen
+        other: "%{count} imágenes"
+      insert: Insertar imagen
+      media_folder_delete_confirmation_html: "¿Estás seguro? Las imágenes <strong>no</strong> serán eliminadas."
+      no_folder: No hay folders
       photos: Imágenes
-      rename_folder: 
-      save_media_folder: 
-      upload_from_device: 
-      uploading: 
+      rename_folder: Renombrar folder
+      save_media_folder: Guardar carpeta
+      upload_from_device: Subir desde un dispositivo
+      uploading: Subiendo...
     modal:
       agree: Si, estoy seguro
       cancel: No, cancelar
     navigations:
-      add_menu_item: 
-      add_sub_item: 
-      choose_page: 
-      delete_item: 
-      delete_item_confirmation_html: 
-      description: 
-      navigations: 
-      no_navigations: 
-      sorting_saved: 
+      add_menu_item: Agregar elemento al menú
+      add_sub_item: Agregar sub-elemento
+      choose_page: Elige la página
+      delete_item: Eliminar elemento
+      delete_item_confirmation_html: "¿Estás seguro que quieres <span class='font-semibold'>eliminar</span>? este elemento?"
+      description: Agrega u ordena los elementos a tu preferencia. También puedes agregar elementos anidados al menú (opcional).
+      navigations: Navegación
+      no_navigations: Este sitio no cuenta con navegación. Puedes configurarlo en las opciones de tu tema.
+      sorting_saved: Se guardó el ordenamiento
     notifications:
       alert: Ups! Algo salió mal
       information: Información
       login: Primero debes ingresar
       wrong_username_or_password: Email o password incorrecto
     options:
-      choose_option: 
+      choose_option: Elige una opción
     pages:
-      add_page_to: 
-      add_translation: 
+      add_page_to: 'Agergar página a:'
+      add_translation: Agregar traducción al %{language}
       advanced: Avanzado
-      cannot_be_deleted: 
+      cannot_be_deleted: No se puede eliminar la página
       change_order: Cambiar orden
-      change_view_template: 
-      change_view_template_confirmation: 
+      change_view_template: Cambiar plantilla
+      change_view_template_confirmation: "¿Estás seguro que quieres cambiar la plantilla de tu página? El contenidod el página que no pertenezca a la plantilla será eliminada."
       concept: concepto
-      create: 
+      create: Crear página
       create_page: Nuevo %{template}
-      delete: 
+      delete: Eliminar página
       delete_confirmation: Seguro que quieres eliminar la página <strong>%{subject}</strong>?
-      deleted: 
+      deleted: Página eliminada
       done_changing_order: Ordenamiento finalizado
-      edit_translation: 
+      edit_translation: Editar traducción al %{language}
       invisible_to_search_engines: Tu sitio es invisible para los motores de búsqueda
       invisible_to_search_engines_description: Ingresa a preferencias para activar los motores de búsqueda.
-      main_collection: 
+      main_collection: Colección principal
       materialize_path_confirmation: Estás seguro de que quieres reconstruir la ruta para esta página?
-      missing_translations: 
-      move_page: 
-      moved: 
+      missing_translations: Faltan traducciónes
+      move_page: Mover página
+      moved: Página movida
       new: Nueva página
-      no_pages_yet: 
-      no_parent_page: 
+      no_pages_yet: No hay páginas
+      no_parent_page: No hay páginas padre
       page_content: Contenido
       page_part: Sección de página
       page_seo: Motores de búsqueda
-      path: 
+      path: 'URL:'
       photo_picker: Seleccionar imagen
       photos_picker: Seleccionar imágenes
-      preview: 
-      publish: 
-      published: 
+      preview: Previsualización
+      publish: Publicar
+      published: Página publicada
       rebuild_materialized_path: Recontruir ruta materializada
-      recommended: 
+      recommended: recomendados
       save: Guardar página
-      save_changes: 
-      save_draft: 
+      save_changes: Guardar cambios
+      save_draft: Guardar borrador
       saved: Página guardada
       saving: Guardando...
-      search_engines: 
+      search_engines: Motores de búsqueda
       show_in_menu: invisible
       skip_to_first_child: omitir hasta la primera página hija
-      sorting_saved: 
+      sorting_saved: Ordenamiento guardado
     permanently_delete: Eliminar permanentemente
     photos:
       cannot_be_created: 'Tu imagen no puede ser procesada:'
@@ -265,10 +268,10 @@ es:
       new_folder: Nueva carpeta
       organize: Organizar imágenes
       rename_folder: Renombrar carpeta
-      select_images: 
+      select_images: Seleccionar imágenes
       upload_image: Subir una imagen
     preferences:
-      Analytics: 
+      Analytics: Analíticas
       account: General
       account_description: Preferencias personales
       account_save: Guardar preferencias
@@ -288,47 +291,47 @@ es:
       users_description: Administrar usuarios y administradores
     preview_website: Previsualizar sitio
     resources:
-      edit: 
-      label_description: 
-      manual_sorting: 
-      no_default_template: 
-      saved: 
-      settings: 
-      settings_description: 
+      edit: Editar recurso
+      label_description: User-facing label for this page collection.
+      manual_sorting: Ordenamiento manual
+      no_default_template: No hay plantilla por defecto
+      saved: Colección de páginas guardadas
+      settings: "%{label} configuraciones"
+      settings_description: Todas las páginas de la colección tendrás el prefijo del slug.
     save: Guardar
     search: Buscar...
     settings:
       save: Guardar configuraciones
       title: Configuraciones
     theme:
-      save: 
-      saved: 
-      theme: 
-      theme_description: 
+      save: Guardar tema
+      saved: Tema guardado
+      theme: Tema
+      theme_description: Configura tu tema
     ui:
-      cancel: 
-      delete: 
-      load_more: 
-      move_to: 
-      new_entry: 
-      optional: 
-      rename: 
-      save_changes: 
-      saving: 
+      cancel: Cancelar
+      delete: Borrar
+      load_more: Cargar más
+      move_to: Mover a
+      new_entry: Nueva entrada
+      optional: Opcional
+      rename: Renombrar
+      save_changes: Guardar cambios
+      saving: Guardando...
     users:
-      authorization: 
-      authorization_description: 
+      authorization: Autorización
+      authorization_description: Únicamente los administradores pueden editar usuarios.
       cannot_be_created: El usuario no puede ser
-      delete: 
+      delete: Eliminar usuario
       delete_confirmation_html: Estás seguro que deseas eliminar al usuario <strong>%{user}</strong>?
-      deleted: 
-      last_login: 
-      never_logged_in: 
+      deleted: Usuario eliminado
+      last_login: 'Último inicio de sesión:'
+      never_logged_in: Nunca ha iniciado sesión
       new: Nuevo usuario
-      profile: 
-      profile_description: 
+      profile: Perfil
+      profile_description: Esta información será usada para identificar a los usuarios. Los usuarios deben usar su correo electrónico para iniciar sesión.
       save: Guardar usuario
-      saved: 
+      saved: Usuario guardado
     visit_page: Visitar página
     website:
       all_pages: Todas las páginas
@@ -345,9 +348,9 @@ es:
       heading_2: Encabezado 2
       heading_3: Encabezado 3
       insert_link: Insertar enlace
-      link: 
+      link: Enlace
       paragraph: Párrafo
       quote: Cita
-      unlink: 
-      url: 
-      url_placeholder: 
+      unlink: Quitar enlace
+      url: URL
+      url_placeholder: Inserta una URL

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -24,35 +24,35 @@ es:
         vat_identifier_description: VAT
         youtube: YouTube
       spina/attachment:
-        created_at: Creado en
+        created_at: Creado el
         name: Nombre del archivo
         size: Tamaño
       spina/media_folder:
         name: Nombre
       spina/navigation:
         auto_add_pages: Agregar páginas automáticamente
-        auto_add_pages_description: Páginas nuevas son agregadas automáticamente a esta navegación
+        auto_add_pages_description: Las páginas nuevas son agregadas automáticamente a esta navegación
         label: Etiqueta
         pages: Páginas
         pages_description: Seleccione las páginas que quiere usar en esta navegación
       spina/page:
         ancestry: Página padre
         created_at: Creada el
-        description: Meta description
+        description: Descripción Meta
         description_description: Esta descripción se mostrará en los resultados de búsqueda
         description_placeholder: Descripción corta de tu página
         draft: Concepto
         draft_description: Ideal para cuando tu página no está del todo terminada
         link_url: Redireccionar página
         link_url_description: Reenviar a URL
-        link_url_placeholder: e.g. http://www.example.com/
+        link_url_placeholder: e.g. https://www.example.com/
         menu_title: Título de navegación
         menu_title_placeholder: Deja en blanco para usar el título de la página
-        no_parent: No página padre
+        no_parent: No es una página padre
         resource: Recurso
         seo_title: SEO <title>
         seo_title_description: SEO <description>
-        seo_title_placeholder: Este título es usado en <title>-tag
+        seo_title_placeholder: Este título es usado en el tag <title>
         show_in_menu: Mostrar en navegación
         show_in_menu_description: Si se desactiva esta página no será mostrada en tu navegación
         skip_to_first_child: Reenviar
@@ -113,7 +113,7 @@ es:
     choose_from_library: Elegir de la biblioteca
     close: Cerrar
     delete: Eliminar
-    delete_confirmation: Seguro que quieres eliminar <strong>%{subject}</strong>?
+    delete_confirmation: "¿Estás seguro que quieres eliminar <strong>%{subject}</strong>?"
     edit: Editar
     edit_website: Editar sitio
     forgot_password:
@@ -122,7 +122,7 @@ es:
       new: Olvido su contraseña
       request: Solicitar nueva contraseña
       save: Guardar nueva contraseña
-      success: Puede utilizar su nueva contraseña
+      success: Puedes utilizar tu nueva contraseña
       unknown_user: Este usuario no existe
     images:
       all_images: Todas las imágenes
@@ -131,9 +131,9 @@ es:
       choose_image: Elegir imagen
       choose_images: Elegir imágenes
       confirm_selection: Confimar selección
-      delete: Borrar
-      delete_confirmation_html: Esta seguro que desea borrar esta <strong>imagen</strong>?
-      delete_folder: Borrar carpeta
+      delete: Eliminar
+      delete_confirmation_html: "¿Estás seguro que quieres eliminar esta <strong>imagen</strong>?"
+      delete_folder: Eliminar carpeta
       done_organizing: Terminar el ordenamiento
       insert_image: Insertar imagen
       insert_photo: Insertar foto
@@ -216,18 +216,18 @@ es:
       change_order: Cambiar orden
       change_view_template: Cambiar plantilla
       change_view_template_confirmation: "¿Estás seguro que quieres cambiar la plantilla de tu página? El contenidod el página que no pertenezca a la plantilla será eliminada."
-      concept: concepto
+      concept: borrador
       create: Crear página
       create_page: Nuevo %{template}
       delete: Eliminar página
-      delete_confirmation: Seguro que quieres eliminar la página <strong>%{subject}</strong>?
+      delete_confirmation: "¿Estás seguro que quieres eliminar la página <strong>%{subject}</strong>?"
       deleted: Página eliminada
       done_changing_order: Ordenamiento finalizado
       edit_translation: Editar traducción al %{language}
       invisible_to_search_engines: Tu sitio es invisible para los motores de búsqueda
       invisible_to_search_engines_description: Ingresa a preferencias para activar los motores de búsqueda.
       main_collection: Colección principal
-      materialize_path_confirmation: Estás seguro de que quieres reconstruir la ruta para esta página?
+      materialize_path_confirmation: "¿Estás seguro de que quieres reconstruir la ruta para esta página?"
       missing_translations: Faltan traducciónes
       move_page: Mover página
       moved: Página movida
@@ -259,9 +259,9 @@ es:
       cannot_be_created: 'Tu imagen no puede ser procesada:'
       choose_images: Seleccionar imágenes
       delete: Borrar
-      delete_confirmation: Seguro que deseas eliminar ésta <strong>imagen</strong>?
+      delete_confirmation: "¿Estás seguro que deseas eliminar ésta <strong>imagen</strong>?"
       delete_folder: Borrar carpeta
-      done_organizing: Terminar la organización
+      done_organizing: Terminar el ordenamiento
       insert_photo: Insertar imagen
       insert_photos: Insertar imágenes
       link: 'URL de tu imagen:'
@@ -321,7 +321,7 @@ es:
     users:
       authorization: Autorización
       authorization_description: Únicamente los administradores pueden editar usuarios.
-      cannot_be_created: El usuario no puede ser
+      cannot_be_created: El usuario no se puede guardar
       delete: Eliminar usuario
       delete_confirmation_html: Estás seguro que deseas eliminar al usuario <strong>%{user}</strong>?
       deleted: Usuario eliminado

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -108,6 +108,7 @@ fr:
       delete_confirmation_html: 
       insert: Insérer un document
       insert_multiple: Insérer des documents
+      upload: 
     cancel: Annuler
     choose_from_library: Choisir parmi la bibliothèque
     close: Fermer

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -108,6 +108,7 @@ id:
       delete_confirmation_html: 
       insert: Masukan dokumen
       insert_multiple: Masukan dokumen
+      upload: 
     cancel: Batal
     choose_from_library: Pilih dari pustaka
     close: Tutup

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -108,6 +108,7 @@ it:
       delete_confirmation_html: 
       insert: Inserisci documento
       insert_multiple: Inserisci documenti
+      upload: 
     cancel: Annulla
     choose_from_library: Seleziona dalla libreria
     close: Chiudi

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -108,6 +108,7 @@ nl:
       delete_confirmation_html: Weet je het zeker? Het kan zijn dat dit document in gebruik is op een pagina.
       insert: Document toevoegen
       insert_multiple: Documenten toevoegen
+      upload: 
     cancel: Annuleren
     choose_from_library: Kies uit bibliotheek
     close: Sluiten

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -108,6 +108,7 @@ pl:
       delete_confirmation_html: 
       insert: Wstaw dokument
       insert_multiple: Wstaw dokumenty
+      upload: 
     cancel: Anuluj
     choose_from_library: Wybierz z biblioteki
     close: Zamknij

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -108,6 +108,7 @@ pt-BR:
       delete_confirmation_html: 
       insert: Inserir documento
       insert_multiple: Inserir documentos
+      upload: 
     cancel: Cancelar
     choose_from_library: Escolher da biblioteca
     close: Fechar

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -108,6 +108,7 @@ ro:
       delete_confirmation_html: 
       insert: Inserează document
       insert_multiple: Inserează documente
+      upload: 
     cancel: Anulare
     choose_from_library: Alege din bibliotecă
     close: Închide

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -116,6 +116,7 @@ ru:
       delete_confirmation_html: 
       insert: Вставить документ
       insert_multiple: Вставить документы
+      upload: 
     cancel: Отмена
     choose_from_library: Выбрать из библиотеки
     close: Закрыть

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -108,6 +108,7 @@ sv:
       delete_confirmation_html: 
       insert: Infoga dokument
       insert_multiple: Infoga dokument
+      upload: 
     cancel: Avbryt
     choose_from_library: Välj från bibliotek
     close: Stäng

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -108,6 +108,7 @@ tr:
       delete_confirmation_html: 
       insert: Belge ekle
       insert_multiple: Çoklu belge ekle
+      upload: 
     cancel: İptal
     choose_from_library: Kütüphaneden seç
     close: Kapat

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -108,6 +108,7 @@ zh-CN:
       delete_confirmation_html: 
       insert: 插入文档
       insert_multiple: 插入多个文档
+      upload: 
     cancel: 取消
     choose_from_library: 从库中选择
     close: 关闭

--- a/test/dummy/app/views/demo/pages/demo.html.erb
+++ b/test/dummy/app/views/demo/pages/demo.html.erb
@@ -5,6 +5,10 @@
 <%= content.text :headline %>
 <%= content.html :body %>
 
+<% if has_content?(:attachment) %>
+  <%= link_to "Attachment", content.attachment_url(:attachment) %> 
+<% end %>
+
 <% if has_content?(:image) %>
   <%= content.image_tag :image, resize_to_fill: [100, 100] %>
 <% end %>


### PR DESCRIPTION
Somehow missed this with the Hotwire refactor. Attachment forms now include the appropriate Stimulus controller that sets the signed_blob_id and filename.

Also fixed the upload button for attachments.