### PR TITLE
add links to spina attachments index

### DIFF
--- a/app/views/spina/admin/attachments/_attachment.html.erb
+++ b/app/views/spina/admin/attachments/_attachment.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center h-12 border-b border-gray-200 px-8 hover:bg-white group">
     
     <turbo-frame id="<%= dom_id(attachment) %>_filename" class="font-medium text-gray-800 h-full flex-1 w-56 text-sm flex items-center relative">
-      <span class="truncate"><%= attachment.file.filename %></span>
+      <span class="truncate"><%= link_to attachment.file.filename, file_url(attachment.file) %></span>
     
       <div class="absolute h-full opacity-0 group-hover:opacity-100 flex items-center right-0 pr-3 top-0">
         <%= link_to spina.edit_admin_attachment_path(attachment), class: "btn btn-default h-7 px-2 mr-2 text-xs" do %>

--- a/app/views/spina/admin/attachments/_attachment.html.erb
+++ b/app/views/spina/admin/attachments/_attachment.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center h-12 border-b border-gray-200 px-8 hover:bg-white group">
     
     <turbo-frame id="<%= dom_id(attachment) %>_filename" class="font-medium text-gray-800 h-full flex-1 w-56 text-sm flex items-center relative">
-      <span class="truncate"><%= link_to attachment.file.filename, file_url(attachment.file) %></span>
+      <span class="truncate"><%= link_to attachment.file.filename, file_url(attachment.file), target: :_blank %></span>
     
       <div class="absolute h-full opacity-0 group-hover:opacity-100 flex items-center right-0 pr-3 top-0">
         <%= link_to spina.edit_admin_attachment_path(attachment), class: "btn btn-default h-7 px-2 mr-2 text-xs" do %>


### PR DESCRIPTION
### Context
Hello!
We very much like spina and use it a lot in our projects. For a current project people wanted to be able to add links to uploaded pdf files (e.g. in the Trix editor). Currently the attachments can only be embedded as a part in a theme and there is no way to get a link to the blob. Also this is a easy way to via at least pdf files in the browser.

### Changes proposed in this pull request
Add a link to the attachments.

### Guidance to review
Its just a single line with a link.
