### PR TITLE
Fix transliterations in Babosa 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     ansi (1.5.0)
     attr_json (1.3.0)
       activerecord (>= 5.0.0, < 6.2)
-    babosa (1.0.4)
+    babosa (2.0.0)
     bcrypt (3.1.16)
     breadcrumbs_on_rails (4.1.0)
       railties (>= 5.0)

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -53,7 +53,7 @@ module Spina
     end
 
     def slug
-      url_title.to_s.to_slug.approximate_ascii(*Spina.config.transliterations).normalize.to_s
+      url_title.to_s.to_slug.transliterate(*Spina.config.transliterations).normalize.to_s
     end
     
     def homepage?

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -53,7 +53,7 @@ module Spina
     end
 
     def slug
-      url_title.to_s.to_slug.normalize(transliterations: Spina.config.transliterations)
+      url_title.to_s.to_slug.approximate_ascii(*Spina.config.transliterations).normalize.to_s
     end
     
     def homepage?

--- a/test/models/spina/page_test.rb
+++ b/test/models/spina/page_test.rb
@@ -27,13 +27,13 @@ module Spina
 
     test 'url_title' do
       page = FactoryBot.build(:page, title: 'Some long title')
-      assert_equal page.slug, 'some-long-title'
+      assert_equal 'some-long-title', page.slug
     end
 
     test 'url_title with specific locale' do
       Spina.config.transliterations = %i(latin bulgarian)
       page = FactoryBot.build(:page, title: 'Тест страница')
-      assert_equal page.slug, 'test-stranica'
+      assert_equal 'test-stranica', page.slug
     end
 
     test 'custom slug' do


### PR DESCRIPTION
Transliterations were broken in Babosa v2. Changed to use `approximate_ascii`. This change should also be backwards compatible with <2.0.