### PR TITLE
Exclude view templates from page collections/resources

### DIFF
--- a/app/components/spina/pages/new_page_button_component.html.erb
+++ b/app/components/spina/pages/new_page_button_component.html.erb
@@ -8,14 +8,7 @@
     
     <% dropdown.menu do %>
       <% view_templates.each do |template| %>
-        <%= link_to helpers.spina.new_admin_page_path(view_template: template.name, resource_id: @resource&.id), class: "block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900 relative group", data: {turbo_frame: "modal", action: "reveal#hide"} do %>
-          
-          <% if helpers.asset_available?("spina/view_template_previews/#{template.name}.png") %>
-            <div class="absolute right-0 transform -translate-x-full pr-4 opacity-0 group-hover:opacity-100 top-0">
-              <%= image_tag "spina/view_template_previews/#{template.name}.png", class: 'rounded-md shadow-md block w-full' %>
-            </div>
-          <% end %>
-          
+        <%= link_to helpers.spina.new_admin_page_path(view_template: template.name, resource_id: @resource&.id), class: "block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900", data: {turbo_frame: "modal", action: "reveal#hide"} do %>
           <div class="font-medium text-gray-700">
             <%= template.title %>
             

--- a/app/components/spina/pages/new_page_button_component.html.erb
+++ b/app/components/spina/pages/new_page_button_component.html.erb
@@ -1,0 +1,39 @@
+<% if view_templates.many? %>
+
+  <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
+    <% dropdown.button(classes: "btn btn-primary w-full") do %>
+      <%= helpers.heroicon("plus", style: :solid, class: "w-7 h-7 -ml-2") %>
+      <%=t 'spina.pages.new' %>
+    <% end %>
+    
+    <% dropdown.menu do %>
+      <% view_templates.each do |template| %>
+        <%= link_to helpers.spina.new_admin_page_path(view_template: template.name, resource_id: @resource&.id), class: "block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900 relative group", data: {turbo_frame: "modal", action: "reveal#hide"} do %>
+          
+          <% if helpers.asset_available?("spina/view_template_previews/#{template.name}.png") %>
+            <div class="absolute right-0 transform -translate-x-full pr-4 opacity-0 group-hover:opacity-100 top-0">
+              <%= image_tag "spina/view_template_previews/#{template.name}.png", class: 'rounded-md shadow-md block w-full' %>
+            </div>
+          <% end %>
+          
+          <div class="font-medium text-gray-700">
+            <%= template.title %>
+            
+            <% if template.recommended %>
+              <span class="text-green-500 text-xs"><%=t 'spina.pages.recommended' %></span>
+            <% end %>
+          </div>
+          <div class="text-gray-400"><%= template.description %></div>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+  
+<% else %>
+
+  <%= link_to helpers.spina.new_admin_page_path(view_template: view_template.name, resource_id: resource&.id), class: "btn btn-primary w-full", data: {turbo_frame: "modal"} do %>
+    <%= helpers.heroicon("plus", style: :solid, class: "w-7 h-7 -ml-2") %>
+    <%=t 'spina.pages.new' %>
+  <% end %>
+  
+<% end %>

--- a/app/components/spina/pages/new_page_button_component.rb
+++ b/app/components/spina/pages/new_page_button_component.rb
@@ -1,0 +1,19 @@
+module Spina::Pages
+  class NewPageButtonComponent < Spina::ApplicationComponent
+    attr_reader :view_templates, :resource
+    
+    def initialize(view_templates = [], resource: nil)
+      @view_templates = view_templates
+      @resource = resource
+    end
+    
+    def view_template
+      view_templates.first
+    end
+    
+    def render?
+      view_templates.any?
+    end
+    
+  end
+end

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -8,10 +8,9 @@ module Spina
       def index
         add_breadcrumb I18n.t('spina.website.pages'), spina.admin_pages_path
         
-        
         if params[:resource_id]
           @resource = Resource.find(params[:resource_id])
-          @page_templates = Spina::Current.theme.new_page_templates(recommended: @resource.view_template)
+          @page_templates = Spina::Current.theme.new_page_templates(resource: @resource)
           @pages = @resource.pages.active.roots.includes(:translations)
         else
           @pages = Page.active.sorted.roots.main.includes(:translations)

--- a/app/views/spina/admin/pages/edit_template.html.erb
+++ b/app/views/spina/admin/pages/edit_template.html.erb
@@ -15,7 +15,7 @@
               <%= Spina::Page.human_attribute_name :view_template %>
             </label>
 
-            <%= f.select :view_template, options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name], {'data-page-parts' => template[:page_parts]}] }, @page.view_template), {}, class: "mt-1 form-select w-full" %>
+            <%= f.select :view_template, current_theme.new_page_templates(resource: @page.resource).map{ |template| [template.title, template.name] }, {}, class: "mt-1 form-select w-full" %>
           </div>
         </div>
       </div>

--- a/app/views/spina/admin/pages/index.html.erb
+++ b/app/views/spina/admin/pages/index.html.erb
@@ -8,27 +8,7 @@
     <% end %>
     
     <div class="ml-3">
-      <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
-        <% dropdown.button(classes: "btn btn-primary w-full") do %>
-          <%= heroicon("plus", style: :solid, class: "w-7 h-7 -ml-2") %>
-          <%=t 'spina.pages.new' %>  
-        <% end %>
-        
-        <% dropdown.menu do %>
-          <% @page_templates.each do |template| %>
-            <%= link_to spina.new_admin_page_path(view_template: template.name, resource_id: @resource&.id), class: "block px-4 py-2 text-sm leading-5 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:bg-gray-100 focus:text-gray-900", data: {turbo_frame: "modal", action: "reveal#hide"} do %>
-              <div class="font-medium text-gray-700">
-                <%= template.title %>
-                
-                <% if template.recommended %>
-                  <span class="text-green-500 text-xs"><%=t 'spina.pages.recommended' %></span>
-                <% end %>
-              </div>
-              <div class="text-gray-400"><%= template.description %></div>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
+      <%= render Spina::Pages::NewPageButtonComponent.new(@page_templates, resource: @resource) %>
     </div>
   <% end %>
   

--- a/lib/spina/theme.rb
+++ b/lib/spina/theme.rb
@@ -36,15 +36,17 @@ module Spina
       @public_theme = false
     end
 
-    def new_page_templates(recommended: "")
+    def new_page_templates(resource: nil)
+      page_collection = resource&.name || "main"
       @view_templates.map do |view_template|
         next if is_custom_undeletable_page?(view_template[:name])
+        next if view_template[:exclude_from]&.include?(page_collection)
         
         OpenStruct.new({
           name: view_template[:name],
           title: view_template[:title],
           description: view_template[:description],
-          recommended: view_template[:name] == recommended
+          recommended: view_template[:name] == resource&.view_template
         })
       end.compact.sort_by do |page_template|
         [page_template.recommended ? 0 : 1]

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -64,15 +64,13 @@
   theme.view_templates = [{
     name: 'homepage',
     title: 'Homepage',
-    parts: ['headline', 'body', 'image_collection'],
-    exclude_from: %w(guides)
+    parts: ['headline', 'body', 'image_collection']
   }, {
     name: 'show',
     title: 'Simple page',
     description: "Default layout",
     usage: 'Use for your content',
-    parts: ['body', 'testrepeater'],
-    exclude_from: %w(guides)
+    parts: ['body', 'testrepeater']
   }, {
     name: 'demo',
     title: 'Demo',

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -64,23 +64,27 @@
   theme.view_templates = [{
     name: 'homepage',
     title: 'Homepage',
-    parts: ['headline', 'body', 'image_collection']
+    parts: ['headline', 'body', 'image_collection'],
+    exclude_from: %w(guides)
   }, {
     name: 'show',
     title: 'Simple page',
     description: "Default layout",
     usage: 'Use for your content',
-    parts: ['body', 'testrepeater']
+    parts: ['body', 'testrepeater'],
+    exclude_from: %w(guides)
   }, {
     name: 'demo',
     title: 'Demo',
     description: 'Example including all parts',
-    parts: ['repeater', 'repeater2', 'attachment', 'option', 'body', 'image_collection', 'image', 'portrait', 'landscape', 'wide']
+    parts: ['repeater', 'repeater2', 'attachment', 'option', 'body', 'image_collection', 'image', 'portrait', 'landscape', 'wide'],
+    exclude_from: %w(guides)
   }, {
     name: 'blogpost',
     title: "Blogpost",
     description: 'Article template',
-    parts: ['body']
+    parts: ['body'],
+    exclude_from: %w(main)
   }]
 
   theme.custom_pages = [{


### PR DESCRIPTION
When you have many view templates in a project, it can be difficult for the end user to choose the correct view template. I've added a configuration option to view templates:

```ruby
{
    name: 'blogpost',
    title: "Blogpost",
    description: 'Article template',
    parts: ['body'],
    exclude_from: %w(main)
}
```

You can choose to exclude a view template from a Page collection/Resource. This way view templates are available everywhere by default, but you can choose to exclude them when there's too many.

When there's just one available view template, the New page button will skip the dropdown and go straight to the new page form. 