### PR TITLE
Missing images

### DIFF
--- a/app/components/spina/media_picker/image_component.html.erb
+++ b/app/components/spina/media_picker/image_component.html.erb
@@ -2,7 +2,7 @@
   <button type="button" 
     data-action="media-picker-modal#selectImage selectable#select dblclick->media-picker-modal#instantInsert" 
     data-image-id="<%= @image.id %>"
-    data-signed-blob-id="<%= @image.file.blob.signed_id %>"
+    data-signed-blob-id="<%= @image.file.blob&.signed_id %>"
     data-filename="<%= @image.file.filename %>"
     data-thumbnail="<%= helpers.thumbnail_url(@image) %>"
     data-embedded-url="<%= helpers.embedded_image_url(@image) %>"

--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -32,7 +32,7 @@ module Spina
     end
     
     def content_type(image)
-      image.file.content_type.split("/").last
+      image.file.content_type&.split("/")&.last || I18n.t("spina.images.missing_image")
     end
 
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,7 @@ en:
       insert_photo: Insert photo
       insert_photos: Insert photos
       link: Link
+      missing_image: Missing image
       new_folder: New folder
       organize: Organize
       remove_image: Remove image


### PR DESCRIPTION
If for some reason uploading an image using ActiveStorage fails, you could end up with a broken interface. Now, it'll show you a "missing image" label, so you know which image to delete/reupload.
<img width="376" alt="CleanShot 2021-09-01 at 12 20 27@2x" src="https://user-images.githubusercontent.com/423116/131655054-89e9bba9-2d79-4ef0-b9eb-a9a013e83a53.png">
