### PR TITLE
Add closing h1 to default homepage view

### DIFF
--- a/lib/generators/spina/templates/app/views/default/pages/homepage.html.erb
+++ b/lib/generators/spina/templates/app/views/default/pages/homepage.html.erb
@@ -1,2 +1,2 @@
-<h1><%= current_page.title %>
+<h1><%= current_page.title %></h1>
 <%= content.html :text %>


### PR DESCRIPTION
The installed default homepage view is missing a closing h1 tag. This PR adds it :) 