### PR TITLE
Add a default position to new pages

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -26,6 +26,8 @@ module Spina
     scope :sorted, -> { order(:position) }
     scope :live, -> { active.where(draft: false) }
     scope :in_menu, -> { where(show_in_menu: true) }
+    
+    before_create :set_default_position
 
     # Copy resource from parent
     before_save :set_resource_from_parent, if: -> { parent.present? }
@@ -102,6 +104,10 @@ module Spina
     end
 
     private
+    
+      def set_default_position
+        self.position = self.class.maximum(:position).to_i.next
+      end
 
       def set_resource_from_parent
         self.resource_id = parent.resource_id

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -106,7 +106,7 @@ module Spina
     private
     
       def set_default_position
-        self.position = self.class.maximum(:position).to_i.next
+        self.position ||= self.class.maximum(:position).to_i.next
       end
 
       def set_resource_from_parent

--- a/test/models/spina/page_test.rb
+++ b/test/models/spina/page_test.rb
@@ -64,6 +64,11 @@ module Spina
       page = FactoryBot.create :about_page, title: "About"
       assert_equal "/about-2", page.materialized_path
     end
+    
+    test 'page has a position' do
+      page = FactoryBot.create :about_page, title: "About"
+      assert_not_nil page.position
+    end
 
   end
 end


### PR DESCRIPTION
New pages should always have a position set to the maximum existing position + 1. That way new pages will always appear at the bottom. This also applies to pages in resources/page collections.