### PR TITLE
Eager load Stimulus controllers using stimulus-loading.js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   
   # System tests
   gem 'capybara'
-  gem 'selenium-webdriver', '4.0.0.rc3'
+  gem 'selenium-webdriver', '~> 4.0.0'
   gem 'webdrivers'
 
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,9 +230,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.0.0.rc3)
+    selenium-webdriver (4.0.0)
       childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2)
+      rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     simplecov (0.13.0)
       docile (~> 1.1.0)
@@ -282,7 +282,7 @@ DEPENDENCIES
   puma
   rails (~> 6.1.4)
   rails-controller-testing
-  selenium-webdriver (= 4.0.0.rc3)
+  selenium-webdriver (~> 4.0.0)
   simplecov
   spina!
   webdrivers

--- a/app/assets/javascripts/spina/application.js
+++ b/app/assets/javascripts/spina/application.js
@@ -1,3 +1,3 @@
 import "@hotwired/turbo-rails"
-import "@hotwired/stimulus-autoloader"
 import "libraries/trix"
+import "controllers"

--- a/app/assets/javascripts/spina/controllers/application.js
+++ b/app/assets/javascripts/spina/controllers/application.js
@@ -1,0 +1,11 @@
+import { Application } from "@hotwired/stimulus"
+
+const application = Application.start()
+
+// Configure Stimulus
+application.warnings = true
+application.debug = false
+window.Stimulus = application
+
+export { application }
+

--- a/app/assets/javascripts/spina/controllers/index.js
+++ b/app/assets/javascripts/spina/controllers/index.js
@@ -1,0 +1,5 @@
+import { application } from "controllers/application"
+
+// Eager load all Stimulus controllers
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)

--- a/app/helpers/spina/spina_helper.rb
+++ b/app/helpers/spina/spina_helper.rb
@@ -1,10 +1,11 @@
 module Spina::SpinaHelper
 
-  def spina_importmap_tags(entry_point = "application")
+  def spina_importmap_tags(entry_point = "application", shim: true)
     safe_join [
       javascript_inline_importmap_tag(Spina.config.importmap.to_json(resolver: self)),
       javascript_importmap_module_preload_tags(Spina.config.importmap),
-      javascript_importmap_shim_tag,
+      (javascript_importmap_shim_nonce_configuration_tag if shim),
+      (javascript_importmap_shim_tag if shim),
       javascript_import_module_tag(entry_point)
     ], "\n"
   end

--- a/config/initializers/importmap.rb
+++ b/config/initializers/importmap.rb
@@ -1,7 +1,7 @@
 Spina.config.importmap.draw do
   # Stimulus & Turbo
   pin "@hotwired/stimulus", to: "stimulus.js"
-  pin "@hotwired/stimulus-autoloader", to: "stimulus-autoloader.js"
+  pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
   pin "@hotwired/turbo-rails", to: "turbo.js"
   
   # Spina entrypoint

--- a/test/factories/accounts.rb
+++ b/test/factories/accounts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :account, class: Spina::Account do
+  factory :account, class: "Spina::Account" do
     name { 'My Website' }
     email { 'bram@spinacms.com' }
     preferences { { theme: 'demo' } }

--- a/test/factories/media_folder.rb
+++ b/test/factories/media_folder.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :media_folder, class: Spina::MediaFolder do
+  factory :media_folder, class: "Spina::MediaFolder" do
     name { "Header images" }
   end
 end

--- a/test/factories/navigation.rb
+++ b/test/factories/navigation.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
-  factory :navigation, class: Spina::Navigation do
+  factory :navigation, class: "Spina::Navigation" do
     name { "custom-nav" }
     label { "Custom nav" }
   end
   
-  factory :navigation_item, class: Spina::NavigationItem do
-    navigation
+  factory :navigation_item, class: "Spina::NavigationItem" do
+    association :page, title: "A page"
   end
 end

--- a/test/factories/page/translations.rb
+++ b/test/factories/page/translations.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :page_translation, class: Spina::Page::Translation do
+  factory :page_translation, class: "Spina::Page::Translation" do
     locale { 'nl' }
   end
 end

--- a/test/factories/pages.rb
+++ b/test/factories/pages.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :page, class: Spina::Page do
+  factory :page, class: "Spina::Page" do
     draft { false }
     active { true }
 

--- a/test/factories/parts.rb
+++ b/test/factories/parts.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
-  factory :base_part, class: Spina::Parts::Base do
+  factory :base_part, class: "Spina::Parts::Base" do
     skip_create
 
-    factory :line_part, class: Spina::Parts::Line do
+    factory :line_part, class: "Spina::Parts::Line" do
       content { 'a line of text' }
     end
   end

--- a/test/factories/resources.rb
+++ b/test/factories/resources.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :resource, class: Spina::Resource do
+  factory :resource, class: "Spina::Resource" do
 
     factory :breweries do
       name { 'breweries' }

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user, class: Spina::User do
+  factory :user, class: "Spina::User" do
     name  { 'Bram' }
     email { 'bram@denkgroot.com' }
     password { 'password' }

--- a/test/integration/spina/admin/pages_test.rb
+++ b/test/integration/spina/admin/pages_test.rb
@@ -53,7 +53,7 @@ module Spina
         
         patch "/admin/pages/#{@page.id}/move", params: {page: {parent_id: @homepage.id}}
         @page.reload
-        assert_equal @page.parent, @homepage
+        assert_equal @page.parent.id, @homepage.id
       end
       
       test "change a view template" do

--- a/test/integration/spina/api/navigations_test.rb
+++ b/test/integration/spina/api/navigations_test.rb
@@ -8,9 +8,9 @@ module Spina
 
         @routes = Engine.routes
         @account = FactoryBot.create :account
-        @navigation = FactoryBot.create :navigation
-        @page = FactoryBot.create :homepage
-        FactoryBot.create :navigation_item, page: @page, navigation: @navigation
+        @navigation = FactoryBot.create(:navigation) do |navigation|
+          FactoryBot.create_list(:navigation_item, 3, navigation: navigation)
+        end
       end
 
       test "get all navigations" do

--- a/test/system/spina/admin/editing_pages_test.rb
+++ b/test/system/spina/admin/editing_pages_test.rb
@@ -35,7 +35,7 @@ module Spina
       click_on "Homepage"
       find_link(nil, href: /\/admin\/embeds\/new/).click
       click_link "Youtube"
-      assert_selector "label", text: "Youtube URL", wait: 5
+      assert_selector "label", text: "Youtube URL"
       fill_in "embeddable[url]", with: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
       click_button "Embed component"
       assert_selector "trix-editor spina-embed", text: "Rick Astley - Never Gonna Give You Up (Official Music Video)"


### PR DESCRIPTION
Refactored the way Spina loads Stimulus controllers to match the preferred setup in `stimulus-rails`.