### PR TITLE
Use Spina.mounted_at to generate paths when not mounted at root

### DIFF
--- a/app/controllers/concerns/spina/frontend.rb
+++ b/app/controllers/concerns/spina/frontend.rb
@@ -53,7 +53,7 @@ module Spina
       end
 
       def spina_request_path
-        segments = ['/', params[:locale], params[:id]].compact
+        segments = [Spina.mounted_at, params[:locale], params[:id]].compact
         File.join(*segments)
       end
 

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -127,7 +127,7 @@ module Spina
         else
           [Spina.mounted_at, Mobility.locale, generate_materialized_path]
         end
-        File.join(*segments.compact)
+        File.join(*segments.map(&:to_s).compact)
       end
 
       def generate_materialized_path

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -122,11 +122,12 @@ module Spina
       end
 
       def localized_materialized_path
-        if Mobility.locale == I18n.default_locale
-          generate_materialized_path.prepend('/')
+        segments = if Mobility.locale == I18n.default_locale
+          [Spina.mounted_at, generate_materialized_path]
         else
-          generate_materialized_path.prepend("/#{Mobility.locale}/").gsub(/\/\z/, "")
+          [Spina.mounted_at, Mobility.locale, generate_materialized_path]
         end
+        File.join(*segments.compact)
       end
 
       def generate_materialized_path

--- a/docs/v2/getting_started/3_existing_project.md
+++ b/docs/v2/getting_started/3_existing_project.md
@@ -12,3 +12,19 @@ The installer will help you setup your first user.
 Restart your server and access Spina at `/admin`.
 
 If you're already using `/admin` for something else, you can change that in `config/initializers/spina.rb`.
+
+## Mounting path
+
+The default mount path for Spina is at the root of your Rails app "/":
+
+```ruby
+mount Spina::Engine => "/"
+```
+
+You can change this to a subdirectory like this:
+
+```ruby
+mount Spina::Engine => "/blog"
+```
+
+Keep in mind that when pages are saved, the URLs are stored in the database as "materialized paths". Changing Spina's mount path means you have to regenerate all materialized paths. You can do that by calling `.save` on each page.

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -88,5 +88,10 @@ module Spina
       
       config_obj
     end
+    
+    def mounted_at
+      Spina::Engine.routes.find_script_name({})
+    end
+    
   end
 end

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -9,7 +9,7 @@ require 'mobility'
 require 'rack-rewrite'
 require 'babosa'
 require 'attr_json'
-require 'view_component/engine'
+require 'view_component'
 require 'jsonapi/serializer'
 require 'browser'
 


### PR DESCRIPTION
Since the beginning, Spina has always assumed it was mounted at `/`. This PR adds support for other paths.

Spina uses `Spina::Engine.routes.find_script_name({})` to find the path it's mounted at. Rails doesn't include a nice method for getting an engine's mount path, so I'm not 100% sure about this. An alternative would be to add a configurable setting in `spina.rb` to set the mount path, but then you'll have to make sure that config is always in sync with your routes file.

A warning though: once set, all paths will be generated using the mount location. That means that if you change it later, you'll have to regenerate all page paths.