### PR TITLE
Require ruby 2.7

### DIFF
--- a/spina.gemspec
+++ b/spina.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
   gem.description = 'CMS'
   gem.license     = 'MIT'
   
+  gem.required_ruby_version     = ">= 2.7.0"
+  
   gem.metadata = {
     "homepage_uri" => "https://www.spinacms.com",
     "bug_tracker_uri" => "https://github.com/SpinaCMS/Spina/issues",


### PR DESCRIPTION
Importmaps don't work properly on ruby 2.6, so to prevent people from getting stuck on weird error messages let's just require 2.7.

Also, Rails 7 will require 2.7.