### PR TITLE
Add spina:install and spina:seed tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem 'spina'
 
 Run the installer to start the setup process:
 
-    rails spina:install [--silent] [--seed-only]
+    rails spina:install [--silent] [--first-deploy]
 
 The installer will help you create your first user interactively, unless you choose the optional `--silent` flag : in this case, defaults will apply.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem 'spina'
 
 Run the installer to start the setup process:
 
-    rails spina:install [--silent] [--first-deploy]
+    rails g spina:install [--silent] [--first-deploy]
 
 The installer will help you create your first user interactively, unless you choose the optional `--silent` flag : in this case, defaults will apply.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gem 'spina'
 
 Run the installer to start the setup process:
 
-    rails g spina:install [--silent]
+    rails spina:install [--silent] [--seed-only]
 
 The installer will help you create your first user interactively, unless you choose the optional `--silent` flag : in this case, defaults will apply.
 

--- a/docs/v1/getting_started/2_install_spina.md
+++ b/docs/v1/getting_started/2_install_spina.md
@@ -9,7 +9,7 @@ gem 'spina'
 Make sure you run the installer to get started.
 
 ```
-rails g spina:install
+rails spina:install
 ```
 
 The installer will help you setup your first user.

--- a/docs/v1/getting_started/3_existing_project.md
+++ b/docs/v1/getting_started/3_existing_project.md
@@ -5,7 +5,7 @@ If you already have an existing Rails project, just add `gem "spina"` to your Ge
 Run the installer to get started.
 
 ```
-rails g spina:install
+rails spina:install
 ```
 
 The installer will help you setup your first user.

--- a/docs/v2/1_getting_started.md
+++ b/docs/v2/1_getting_started.md
@@ -10,7 +10,7 @@ gem 'spina'
 
 Run the installer to start the setup process:
 
-    rails g spina:install
+    rails spina:install
 
 The installer will help you create your first user.
 

--- a/docs/v2/getting_started/2_installing_spina.md
+++ b/docs/v2/getting_started/2_installing_spina.md
@@ -6,6 +6,12 @@ Start by creating a new Rails app using a PostgreSQL database.
 rails new yourwebsite --database=postgresql
 ```
 
+Create a database.
+
+```
+rails db:create
+```
+
 Run the ActiveStorage installer to install ActiveStorage.
 
 ```

--- a/docs/v2/getting_started/2_installing_spina.md
+++ b/docs/v2/getting_started/2_installing_spina.md
@@ -21,7 +21,7 @@ gem 'spina'
 Run `bundle install` and run the installer to install Spina CMS.
 
 ```
-rails g spina:install
+rails spina:install
 ```
 
 The installer will ask a couple of questions to help you setup your website.

--- a/docs/v2/getting_started/3_existing_project.md
+++ b/docs/v2/getting_started/3_existing_project.md
@@ -5,7 +5,7 @@ If you already have an existing Rails project, just add `gem "spina"` to your Ge
 Run the installer to get started.
 
 ```
-rails g spina:install
+rails spina:install
 ```
 
 The installer will help you setup your first user.

--- a/docs/v2/getting_started/6_deploying.md
+++ b/docs/v2/getting_started/6_deploying.md
@@ -1,6 +1,6 @@
 # Deploying
 
-Deploying a Spina CMS project is no different from any other Rails project. Spina includes a task that you can run on your first deployment in a production environment:
+Deploying a Spina CMS project is no different than any other Rails project. Spina includes a task that you can run on your first deployment in a production environment:
 
 ```
 rails spina:first_deploy

--- a/docs/v2/getting_started/6_deploying.md
+++ b/docs/v2/getting_started/6_deploying.md
@@ -1,0 +1,9 @@
+# Deploying
+
+Deploying a Spina CMS project is no different from any other Rails project. Spina includes a task that you can run on your first deployment in a production environment:
+
+```
+rails spina:first_deploy
+```
+
+This task does the same thing as the install task, except for copying files. 

--- a/lib/generators/spina/install_generator.rb
+++ b/lib/generators/spina/install_generator.rb
@@ -2,32 +2,32 @@ module Spina
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path("../templates", __FILE__)
     
-    class_option :seed_only, type: :boolean, default: false
+    class_option :first_deploy, type: :boolean, default: false
     class_option :silent, type: :boolean, default: false
 
     def create_initializer_file
-      return if Rails.env.production? || options['seed_only']
+      return if first_deploy?
       template 'config/initializers/spina.rb'
     end
 
     def create_mobility_initializer_file
-      return if Rails.env.production? || options['seed_only']
+      return if first_deploy?
       template 'config/initializers/mobility.rb'
     end
 
     def add_route
-      return if Rails.env.production? || options['seed_only']
+      return if first_deploy?
       return if Rails.application.routes.routes.detect { |route| route.app.app == Spina::Engine }
       route "mount Spina::Engine => '/'"
     end
 
     def copy_migrations
-      return if Rails.env.production? || options['seed_only']
+      return if first_deploy?
       rake 'spina:install:migrations'
     end
 
     def run_migrations
-      return if options['seed_only']
+      return if first_deploy?
       rake 'db:migrate'
     end
 
@@ -37,12 +37,12 @@ module Spina
       if talkative_install?
         name = ask("What would you like to name your website? [#{name}]").presence || name
       end
-      account = ::Spina::Account.first_or_create.update_attribute(:name, name)
+      account = ::Spina::Account.first_or_create.update(name: name)
     end
 
     def set_theme
       account = ::Spina::Account.first
-      return if account.theme.present? && !no?("Theme '#{account.theme} is set. Skip? [Yn]")
+      return if account.theme.present? && !no?("Theme '#{account.theme}' is set. Skip? [Yn]")
 
       theme = account.theme || themes.first
       if talkative_install?
@@ -51,11 +51,11 @@ module Spina
                 end until theme.in? themes
       end
 
-      account.update_attribute(:theme, theme)
+      account.update(theme: theme)
     end
 
     def copy_template_files
-      return if options['seed_only']
+      return if options['first_deploy']
       theme = ::Spina::Account.first.theme
       if theme.in? ['default', 'demo']
         template "config/initializers/themes/#{theme}.rb"
@@ -104,6 +104,10 @@ module Spina
       def themes
         themes = Spina::Theme.all.map(&:name)
         themes | ['default', 'demo']
+      end
+      
+      def first_deploy?
+        options['first_deploy']
       end
 
       def talkative_install?

--- a/lib/tasks/spina_tasks.rake
+++ b/lib/tasks/spina_tasks.rake
@@ -1,5 +1,15 @@
 namespace :spina do
-
+  
+  desc "Install Spina"
+  task install: :environment do
+    Rails::Command.invoke :generate, ["spina:install"]
+  end
+  
+  desc "Seed Spina"
+  task seed: :environment do
+    Rails::Command.invoke :generate, ["spina:install", "--seed-only"]
+  end
+  
   desc "Generate all pages based on the theme config"
   task bootstrap: :environment do
     Spina::Account.first.save

--- a/lib/tasks/spina_tasks.rake
+++ b/lib/tasks/spina_tasks.rake
@@ -14,7 +14,7 @@ namespace :spina do
   desc "First deploy"
   task first_deploy: :environment do
     # First deploy will run the same steps as the install generator, but skips copying files
-    Rails::Command.invoke :generate, ["spina:install", "--first_deploy"]
+    Rails::Command.invoke :generate, ["spina:install", "--first-deploy"]
   end
   
   desc "Generate all pages based on the theme config"

--- a/lib/tasks/spina_tasks.rake
+++ b/lib/tasks/spina_tasks.rake
@@ -2,12 +2,19 @@ namespace :spina do
   
   desc "Install Spina"
   task install: :environment do
-    Rails::Command.invoke :generate, ["spina:install"]
+    begin
+      ActiveRecord::Base.connection
+    rescue ActiveRecord::NoDatabaseError
+      puts "ERROR: database does not exist, run \"rails db:create\" first"
+    else
+      Rails::Command.invoke :generate, ["spina:install"]
+    end
   end
   
-  desc "Seed Spina"
-  task seed: :environment do
-    Rails::Command.invoke :generate, ["spina:install", "--seed-only"]
+  desc "First deploy"
+  task first_deploy: :environment do
+    # First deploy will run the same steps as the install generator, but skips copying files
+    Rails::Command.invoke :generate, ["spina:install", "--first_deploy"]
   end
   
   desc "Generate all pages based on the theme config"


### PR DESCRIPTION
Instead of running the generator directly, this PR adds `rails spina:install` and `rails spina:first_deploy` as rake tasks.

The `rails spina:install` task also checks to see if your database exists before doing anything. I always forget. 🤓

The `first_deploy` task runs the same generator as `install`, but skips copying files. You can use that to seed your database with your first records (Account/User) to get started in a fresh database. Useful for production, but also after resetting your database.