### PR TITLE
v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Spina CMS Changelog
 
+## 2.6
+
+### 2.6.0 (December 9th, 2021)
+* Spina CMS now requires Ruby 2.7+
+* Added Embed generator for Trix
+* Added --silent option to install generator
+* Added --first-deploy option to install generator
+* Added spina:first_deploy task
+* Added support for different mount paths
+* Fixed routes catch all bug
+* Updated gem dependencies
+
 ## 2.5
 
 ### 2.5.0 (October 17th, 2021)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina (2.5.0)
+    spina (2.6.0)
       ancestry
       attr_json
       babosa
@@ -18,7 +18,7 @@ PATH
       rails (>= 6.0)
       sass-rails
       stimulus-rails (>= 0.7.0)
-      turbo-rails (>= 0.8.0)
+      turbo-rails (~> 0.9)
       view_component (~> 2.32)
 
 GEM
@@ -125,7 +125,7 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     importmap-rails (0.9.4)
       rails (>= 6.0.0)
-    json (2.5.1)
+    json (2.6.1)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     kaminari (1.2.1)
@@ -214,12 +214,12 @@ GEM
       rake (>= 0.13)
       thor (~> 1.0)
     rake (13.0.6)
-    regexp_parser (2.1.1)
+    regexp_parser (2.2.0)
     request_store (1.5.0)
       rack (>= 1.4)
     rexml (3.2.5)
     ruby-progressbar (1.11.0)
-    ruby-vips (2.1.3)
+    ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.3.2)
     sass-rails (6.0.0)

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "2.5.0"
+  VERSION = "2.6.0"
 end

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'attr_json'
   gem.add_dependency 'view_component', '~> 2.32'
   gem.add_dependency 'importmap-rails', '>= 0.7.6'
-  gem.add_dependency 'turbo-rails', '>= 0.8.0'
+  gem.add_dependency 'turbo-rails', '~> 0.9'
   gem.add_dependency 'stimulus-rails', '>= 0.7.0'
   gem.add_dependency 'babosa'
   gem.add_dependency 'jsonapi-serializer'


### PR DESCRIPTION
# Changelog

* Spina CMS now requires Ruby 2.7+
* Added Embed generator for Trix
* Added --silent option to install generator
* Added --first-deploy option to install generator
* Added spina:first_deploy task
* Added support for different mount paths
* Fixed routes catch all bug
* Updated gem dependencies