### PR TITLE
Refactor page select navigations UI

### DIFF
--- a/app/controllers/spina/admin/navigation_items_controller.rb
+++ b/app/controllers/spina/admin/navigation_items_controller.rb
@@ -5,7 +5,7 @@ module Spina
       
       def new
         @navigation_item = @navigation.navigation_items.new(parent_id: params[:parent_id])
-        @pages = Page.sorted
+        @pages = Page.sorted.main.includes(:translations)
       end
       
       def create

--- a/app/views/spina/admin/navigation_items/_form.html.erb
+++ b/app/views/spina/admin/navigation_items/_form.html.erb
@@ -10,7 +10,11 @@
           </h3>
     
           <div class="mt-3">
-            <%= f.select :page_id, @pages.map{|page| [page.menu_title, page.id]}, {disabled: @navigation.navigation_items.pluck(:page_id), include_blank: t('spina.navigations.choose_page')}, class: 'form-select w-full' %>
+            
+            <div class="border border-gray-300 rounded-md bg-white">
+              <%= render Spina::Pages::PageSelectComponent.new("navigation_item[page_id]", @pages, include_blank: t("spina.navigations.choose_page"), disabled: @navigation.navigation_items.pluck(:page_id)) %>
+            </div>
+            
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adding navigation items becomes impractical if you have more than a few pages. 

Instead of rendering one giant `<select>` containing all `Spina::Page` objects, we can just render everything from the main collection using the `Spina::Pages::PageSelectComponent`:

<img width="580" alt="CleanShot 2021-12-23 at 14 16 29@2x" src="https://user-images.githubusercontent.com/423116/147245946-7446c761-78a3-4ef8-8bd1-70428c127edc.png">

