### PR TITLE
Add timeout to image collection controller - Fixes #932

### DIFF
--- a/app/assets/javascripts/spina/controllers/image_collection_controller.js
+++ b/app/assets/javascripts/spina/controllers/image_collection_controller.js
@@ -7,9 +7,11 @@ export default class extends Controller {
   }
   
   connect() {
-    this.sortable = Sortable.create(this.collectionTarget, {
-      animation: 150
-    })
+    setTimeout(function() {
+      this.sortable = Sortable.create(this.collectionTarget, {
+        animation: 150
+      })
+    }.bind(this), 250)
   }
   
   removeImage(event) {


### PR DESCRIPTION
The unique-id-controller replaces HTML which sometimes breaks Sortable for ImageCollections. By adding a small timeout we can temporarily fix this. We should use a different method than replacing the HTML for the unique-id-controller.