### PR TITLE
Add hints to parts when editing pages

### DIFF
--- a/app/models/concerns/spina/partable.rb
+++ b/app/models/concerns/spina/partable.rb
@@ -10,7 +10,7 @@ module Spina
         part = find_part(attributes[:name]) || attributes[:part_type].constantize.new
 
         # Copy all attributes to part
-        %w(name title options).each do |attribute|
+        %w(name title hint options).each do |attribute|
           part.public_send("#{attribute}=", attributes[attribute.to_sym]) if part.respond_to?(attribute)
         end
 

--- a/app/models/spina/parts/base.rb
+++ b/app/models/spina/parts/base.rb
@@ -5,8 +5,9 @@ module Spina
 
       attr_json_config(unknown_key: :strip)
 
-      attr_json :title, :string
       attr_json :name, :string
+      
+      attr_accessor :title, :hint
 
       def label
         content&.to_s

--- a/app/views/spina/admin/parts/attachments/_form.html.erb
+++ b/app/views/spina/admin/parts/attachments/_form.html.erb
@@ -1,8 +1,9 @@
 <div class="mt-6" data-controller="attachment-picker">
   <label for="price" class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
 
   <%= f.hidden_field :signed_blob_id, data: {attachment_picker_target: 'signedBlobId'} %>
   <%= f.hidden_field :filename, data: {attachment_picker_target: 'filename'} %>
 
-  <%= f.select :attachment_id, Spina::Attachment.sorted.map{|attachment| [attachment.file&.filename, attachment.id, data: {signed_blob_id: attachment.file&.blob&.signed_id, filename: attachment.file&.filename}]}, {include_blank: t("spina.attachments.choose_attachment")}, {class: "form-select", data: {action: "attachment-picker#pick"}} %>
+  <%= f.select :attachment_id, Spina::Attachment.sorted.map{|attachment| [attachment.file&.filename, attachment.id, data: {signed_blob_id: attachment.file&.blob&.signed_id, filename: attachment.file&.filename}]}, {include_blank: t("spina.attachments.choose_attachment")}, {class: "form-select mt-1", data: {action: "attachment-picker#pick"}} %>
 </div>

--- a/app/views/spina/admin/parts/image_collections/_form.html.erb
+++ b/app/views/spina/admin/parts/image_collections/_form.html.erb
@@ -10,6 +10,7 @@
   <label class="block text-sm leading-5 font-medium text-gray-700">
     <%= f.object.title %>
   </label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
 
   <div class="flex items-start mt-1">
     <div class="flex items-center" data-image-collection-target="collection">

--- a/app/views/spina/admin/parts/images/_form.html.erb
+++ b/app/views/spina/admin/parts/images/_form.html.erb
@@ -2,6 +2,7 @@
   <label class="block text-sm leading-5 font-medium text-gray-700">
     <%= f.object.title %>
   </label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
 
   <%= f.hidden_field :signed_blob_id, data: {media_picker_target: "signedBlobId"} %>
   <%= f.hidden_field :filename, data: {media_picker_target: "filename"} %>

--- a/app/views/spina/admin/parts/lines/_form.html.erb
+++ b/app/views/spina/admin/parts/lines/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="mt-6">
   <label class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
   <div class="mt-1">
     <%= f.text_field :content, class: "form-input block w-full max-w-5xl sm:text-sm sm:leading-5" %>
   </div>

--- a/app/views/spina/admin/parts/options/_form.html.erb
+++ b/app/views/spina/admin/parts/options/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="mt-6">
   <label for="price" class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
 
-  <%= f.select :value, f.object.options, {include_blank: t("spina.options.choose_option")}, class: "form-select" %>
+  <%= f.select :value, f.object.options, {include_blank: t("spina.options.choose_option")}, class: "form-select mt-1" %>
 </div>

--- a/app/views/spina/admin/parts/repeaters/_form.html.erb
+++ b/app/views/spina/admin/parts/repeaters/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="mt-6" data-controller="repeater">
   <label class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
 
   <div class="-mt-4 flex flex-col md:flex-row" data-controller="tabs" data-tabs-active="bg-spina-dark bg-opacity-10 text-gray-900" data-tabs-inactive="text-gray-500">
     <div class="md:w-64 md:pr-6">

--- a/app/views/spina/admin/parts/texts/_form.html.erb
+++ b/app/views/spina/admin/parts/texts/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="mt-6" data-controller="unique-id" data-unique-id="<%= f.object.object_id %>">
   <label class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint %></div>
   <div class="mt-1 relative">
     <%= f.hidden_field :content, id: "#{f.object.object_id}_input" %>
 

--- a/docs/v2/themes/1_parts.md
+++ b/docs/v2/themes/1_parts.md
@@ -23,35 +23,33 @@ Spina uses an initializer to create the basic building blocks of your page. Ther
 When you install Spina, you will see the following in config/initializers/themes/default.rb
 
 ```ruby
-::Spina::Theme.register do |theme|
+Spina::Theme.register do |theme|
   theme.name = 'default'
-  theme.title = 'Default Theme'
+  theme.title = 'Default theme'
+  
+  theme.parts = [
+    {name: 'text',  title: "Body", hint: "Your main content", part_type: "Spina::Parts::Text"}
+  ]
+  
+  theme.view_templates = [
+    {name: 'homepage', title: 'Homepage', parts: %w(text)}, 
+    {name: 'show', title: 'Page', parts: %w(text)}
+  ]
+  
+  theme.custom_pages = [
+    {name: 'homepage', title: "Homepage", deletable: false, view_template: "homepage"},
+  ]
 
-  theme.parts = [{
-    name:         'content',
-    title:        'Content',
-    part_type:    'Spina::Parts::Text'
-  }]
-
-  theme.view_templates = [{
-    name:  'homepage',
-    title: 'Homepage',
-    parts: %w(content)
-  }, {
-    name: 'show',
-    title:        'Default',
-    description:  'A simple page',
-    usage:        'Use for your content',
-    parts:        %w(content)
-  }]
-
-  theme.custom_pages = [{
-    name:           'homepage',
-    title:          'Homepage',
-    deletable:      false,
-    view_template:  'homepage'
-  }]
+  theme.navigations = [
+    {name: 'main', label: 'Main navigation'}
+  ]
+  
+  theme.layout_parts = []
+  theme.resources = []
+  theme.plugins = []
+  theme.embeds = []
 end
+
 ```
 
 Right now, the default theme is applying a title to the page, with a simple text div below it. Go to /admin on your app and have a look. Edit the textbox and go to preview the page.

--- a/lib/generators/spina/templates/config/initializers/themes/default.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/default.rb
@@ -21,7 +21,7 @@ Spina::Theme.register do |theme|
   # - Option
   # - Repeater
   theme.parts = [
-    {name: 'text',  title: "Body", part_type: "Spina::Parts::Text"}
+    {name: 'text',  title: "Body", hint: "Your main content", part_type: "Spina::Parts::Text"}
   ]
   
   # View templates

--- a/lib/generators/spina/templates/config/initializers/themes/demo.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/demo.rb
@@ -23,10 +23,10 @@ Spina::Theme.register do |theme|
   theme.parts = [
     {name: 'repeater', title: "Repeater", part_type: "Spina::Parts::Repeater", parts: %w(line image headline)}, 
     {name: 'line', title: "Line", part_type: "Spina::Parts::Line"}, 
-    {name: 'body', title: "Body", part_type: "Spina::Parts::Text"}, 
+    {name: 'body', title: "Body", hint: "Your content", part_type: "Spina::Parts::Text"}, 
     {name: "image_collection", title: "Image collection", part_type: "Spina::Parts::ImageCollection"},
     {name: 'image', title: "Image", part_type: "Spina::Parts::Image"}, 
-    {name: 'headline', title: "Headline", part_type: "Spina::Parts::Line"}, 
+    {name: 'headline', title: "Headline", hint: "Used in the header", part_type: "Spina::Parts::Line"}, 
     {name: 'footer', title: "Footer", part_type: "Spina::Parts::Text"}
   ]
 

--- a/test/dummy/config/initializers/themes/default.rb
+++ b/test/dummy/config/initializers/themes/default.rb
@@ -6,6 +6,7 @@
   theme.parts = [{
     name:       'text',
     title:      'Text',
+    hint:       'Your main content',
     part_type:  'Spina::Parts::Text'
   }]
 

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -12,7 +12,6 @@ Spina::Theme.register do |theme|
   theme.parts = [{
     name: 'repeater',
     title: "Repeater",
-    hint: "Repeat something",
     part_type: "Spina::Parts::Repeater",
     parts: ['line', 'body', 'image', 'image_collection']
   }, {
@@ -27,17 +26,14 @@ Spina::Theme.register do |theme|
   }, {
     name: 'body',
     title: "Body",
-    hint: "Put all of your main content here",
     part_type: "Spina::Parts::Text"
   }, {
     name: "image_collection",
     title: "Image collection",
-    hint: "Choose multiple images",
     part_type: "Spina::Parts::ImageCollection"
   }, {
     name: 'image',
     title: "Image",
-    hint: "Choose an image",
     part_type: "Spina::Parts::Image"
   }, {name: 'portrait', part_type: 'Spina::Parts::Image', options: {ratio: "portrait"}
   }, {name: 'landscape', part_type: 'Spina::Parts::Image', options: {ratio: "landscape"}
@@ -45,7 +41,7 @@ Spina::Theme.register do |theme|
   }, {
     name: 'headline',
     title: "Headline",
-    hint: "This is what's displayed in your header",
+    hint: "This will be shown in your header",
     part_type: "Spina::Parts::Line"
   }, {
     name: 'footer',
@@ -54,18 +50,15 @@ Spina::Theme.register do |theme|
   }, {
     name: 'option',
     title: "Option",
-    hint: "An option",
     part_type: "Spina::Parts::Option",
     options: [["Left", 'left'], ["Center", 'center'], ["Right", 'right']]
   }, {
     name: 'attachment',
     title: "Attachment",
-    hint: "Pick an attachment",
     part_type: "Spina::Parts::Attachment"
   }, {
     name: 'testrepeater',
     title: 'Testrepeater',
-    hint: "Repeat some content",
     part_type: "Spina::Parts::Repeater",
     parts: %w(line body)
   }]

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -12,6 +12,7 @@ Spina::Theme.register do |theme|
   theme.parts = [{
     name: 'repeater',
     title: "Repeater",
+    hint: "Repeat something",
     part_type: "Spina::Parts::Repeater",
     parts: ['line', 'body', 'image', 'image_collection']
   }, {
@@ -26,14 +27,17 @@ Spina::Theme.register do |theme|
   }, {
     name: 'body',
     title: "Body",
+    hint: "Put all of your main content here",
     part_type: "Spina::Parts::Text"
   }, {
     name: "image_collection",
     title: "Image collection",
+    hint: "Choose multiple images",
     part_type: "Spina::Parts::ImageCollection"
   }, {
     name: 'image',
     title: "Image",
+    hint: "Choose an image",
     part_type: "Spina::Parts::Image"
   }, {name: 'portrait', part_type: 'Spina::Parts::Image', options: {ratio: "portrait"}
   }, {name: 'landscape', part_type: 'Spina::Parts::Image', options: {ratio: "landscape"}
@@ -41,6 +45,7 @@ Spina::Theme.register do |theme|
   }, {
     name: 'headline',
     title: "Headline",
+    hint: "This is what's displayed in your header",
     part_type: "Spina::Parts::Line"
   }, {
     name: 'footer',
@@ -49,15 +54,18 @@ Spina::Theme.register do |theme|
   }, {
     name: 'option',
     title: "Option",
+    hint: "An option",
     part_type: "Spina::Parts::Option",
     options: [["Left", 'left'], ["Center", 'center'], ["Right", 'right']]
   }, {
     name: 'attachment',
     title: "Attachment",
+    hint: "Pick an attachment",
     part_type: "Spina::Parts::Attachment"
   }, {
     name: 'testrepeater',
     title: 'Testrepeater',
+    hint: "Repeat some content",
     part_type: "Spina::Parts::Repeater",
     parts: %w(line body)
   }]


### PR DESCRIPTION
As proposed in #945 , this PR adds the `hint` attribute to Spina parts, allowing the developer to add hints for the end user.

```ruby
# theme.rb
Spina::Theme.register do |theme|

  theme.parts = [{
    name: 'body',
    title: "Body",
    hint: "Put all of your main content here",
    part_type: "Spina::Parts::Text"
  },
  # ...
```

![CleanShot 2022-01-17 at 21 05 53@2x](https://user-images.githubusercontent.com/423116/149831321-782063f5-9bc9-4cb0-98aa-068c9c52da17.png)
.