### PR TITLE
Load environment before running tasks

### DIFF
--- a/lib/tasks/tailwind.rake
+++ b/lib/tasks/tailwind.rake
@@ -5,12 +5,12 @@ SPINA_TAILWIND_COMPILE_COMMAND = "#{Tailwindcss::Engine.root.join("exe/tailwindc
 namespace :spina do
   namespace :tailwind do 
     desc "Build your Tailwind CSS"
-    task :build do
+    task build: :environment do
       Rails::Generators.invoke("spina:tailwind_config", ["--force"])
       system SPINA_TAILWIND_COMPILE_COMMAND
     end
     
-    task :watch do
+    task watch: :environment do
       Rails::Generators.invoke("spina:tailwind_config", ["--force"])
       system "#{SPINA_TAILWIND_COMPILE_COMMAND} -w"
     end


### PR DESCRIPTION
Make sure to run the environment before running Spina's Tailwind rake tasks. Otherwise, the `tailwind_content` isn't loaded properly.