### PR TITLE
Update Documentation on how to create custom Parts

### DIFF
--- a/docs/v2/advanced/1_create_custom_parts.md
+++ b/docs/v2/advanced/1_create_custom_parts.md
@@ -13,7 +13,7 @@ module Spina
       attr_json :movie_id, :integer
 
       def content
-        Movie.find(movie_id)
+        Movie.find_by(id: movie_id)
       end
 
     end
@@ -22,6 +22,8 @@ end
 ```
 
 *In this simplified example we make the content method do a query and return a Movie record. Beware of N+1 queries if you go this route. Generally, the more you store directly in JSON, the better your performance.*
+
+*Any `ActiveRecord::RecordNotFound` Exception will be displayed as 404, which may be happening when using `Movie.find (movie_id)` if movie_id is nil or not found in Database. You should consider using `Movie.find_by (id: movie_id)`, which will not throw an Error but return nil if movie_id is nil or not found in Database.*
 
 ## Step 2. Create a view for page editing
 
@@ -41,6 +43,11 @@ In an initializer, register your newly created part so you can use it in your th
 
 `Spina::Part.register(Spina::Parts::Movie)`
 
-## Step 4. Go wild
+## Step 4. View template example
+```
+<p>Film Director: <%= content(:movie)[:director] %></p>
+```
+
+## Step 5. Go wild
 
 Of course, this is a very simple example. You can store a lot this way. You can take a look at the existing parts in Spina for inspiration. If you want to learn more, you can also [take a look at the attr_json readme](https://github.com/jrochkind/attr_json). 


### PR DESCRIPTION
* added further explanation for Documentation on how to create custom Parts

### Context
I followed the [Documentation](https://spinacms.com/docs/advanced/create-custom-parts) on how to create Custom Parts because I needed to reference a Model Instance. As per my Demands, this Model Reference is optional, thus the corresponding `json_attr` is `nil`.
While testing the Application I got an unexpected 404 when viewing the Page, and tracked it down to an `ActiveRecord::RecordNotFound` Exception on `Model.find(nil)` on that Custom Part. As per [Spina::Frontend Line 6](https://github.com/SpinaCMS/Spina/blob/930e8526c423f0454826ef0476d795cea381b039/app/controllers/concerns/spina/frontend.rb#L6), this Exception will be rescued in an 404. I don't know if this is an expected Behaviour as I think that an `ActiveRecord::RecordNotFound` Exception in development should be displayed as such.
Never the less, changing from `Model.find(nil)` to `Model.find_by(id: nil)` may be the correct way to implement the behavior in the circumstances which are presented in this example, because a potential nil Value in an json_attr will not result in a Error, but in a nil Value on the View itself.

### Changes proposed in this pull request
* changed Docs to use `find_by` instead of `find`
* also added simple Example on how to implement this custom Part in a View

### Guidance to review
* if the Behavior of the 404 is intentionally, the Docs should respond to this.
* wording in doc may be checked and / or corrected (not an native English speaker)
