### PR TITLE
Fixing silent install generator flag and adding rake task

### DIFF
--- a/lib/generators/spina/install_generator.rb
+++ b/lib/generators/spina/install_generator.rb
@@ -32,7 +32,7 @@ module Spina
     end
 
     def create_account
-      return if ::Spina::Account.exists? && !no?('An account already exists. Skip? [Yn]')
+      return if ::Spina::Account.exists? && !talkative_install? || !no?('An account already exists. Skip? [Yn]')
       name = ::Spina::Account.first.try(:name) || 'MySite'
       if talkative_install?
         name = ask("What would you like to name your website? [#{name}]").presence || name
@@ -42,7 +42,7 @@ module Spina
 
     def set_theme
       account = ::Spina::Account.first
-      return if account.theme.present? && !no?("Theme '#{account.theme}' is set. Skip? [Yn]")
+      return if account.theme.present? && !talkative_install? || !no?("Theme '#{account.theme}' is set. Skip? [Yn]")
 
       theme = account.theme || themes.first
       if talkative_install?
@@ -67,7 +67,7 @@ module Spina
     end
 
     def create_user
-      return if ::Spina::User.exists? && !no?('A user already exists. Skip? [Yn]')
+      return if ::Spina::User.exists? && !talkative_install? || !no?('A user already exists. Skip? [Yn]')
 
       email = 'admin@domain.com'
       if talkative_install?

--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -17,6 +17,12 @@ namespace :spina do
     Rails::Command.invoke :generate, ["spina:install", "--first-deploy"]
   end
   
+  desc "Silent First deploy"
+  task silent_first_deploy: :environment do
+    # Silent First deploy will run the same steps as First Deploy but without prompts
+    Rails::Command.invoke :generate, ["spina:install", "--first-deploy", "--silent"]
+  end
+  
   desc "Generate all pages based on the theme config"
   task bootstrap: :environment do
     Spina::Account.first.save


### PR DESCRIPTION
### Context
In order to Dockerize my Rails Application using Spina CMS, i need to automatically setup my database using `rails generate spina:install --first-deploy --silent`, but as a rake task (no rails context available in docker image). The `--first-deploy` flag already has been setup as a rake task, the `--silent` flag not yet. 

### Changes proposed in this pull request
This PR
* adds the rake task `rake spina:silent_first_deploy`, to initialize the database without any console prompts.
* fixes the `--silent` flag itself, which outputs prompts even if silent flag is set (if database already set up)
