### PR TITLE
fixes #979 wrong evaluation in install generator

### DIFF
--- a/lib/generators/spina/install_generator.rb
+++ b/lib/generators/spina/install_generator.rb
@@ -32,7 +32,7 @@ module Spina
     end
 
     def create_account
-      return if ::Spina::Account.exists? && !talkative_install? || !no?('An account already exists. Skip? [Yn]')
+      return if ::Spina::Account.exists? && ( !talkative_install? || !no?('An account already exists. Skip? [Yn]') )
       name = ::Spina::Account.first.try(:name) || 'MySite'
       if talkative_install?
         name = ask("What would you like to name your website? [#{name}]").presence || name
@@ -42,7 +42,7 @@ module Spina
 
     def set_theme
       account = ::Spina::Account.first
-      return if account.theme.present? && !talkative_install? || !no?("Theme '#{account.theme}' is set. Skip? [Yn]")
+      return if account.theme.present? && ( !talkative_install? || !no?("Theme '#{account.theme}' is set. Skip? [Yn]") )
 
       theme = account.theme || themes.first
       if talkative_install?
@@ -67,7 +67,7 @@ module Spina
     end
 
     def create_user
-      return if ::Spina::User.exists? && !talkative_install? || !no?('A user already exists. Skip? [Yn]')
+      return if ::Spina::User.exists? && ( !talkative_install? || !no?('A user already exists. Skip? [Yn]') )
 
       email = 'admin@domain.com'
       if talkative_install?


### PR DESCRIPTION
fixes wrong statement evaluation from pr #979 (short-circuit evaluation)

### Context
My previous PR added a bug in the statement evaluation in the install generator, which would in turn return the function unintentionally if `Spina::Account.exists?` is false.
(`false && !false || !no?("y")` is `true` and would return the function, even if it should not! in addition it would prompt the terminal, even if it should not be required)

### Changes proposed in this pull request
fixed statement evaluation my applying short-circuit evaluation by encapsulating the last part.
(from example above: `false && ( !false || !no?("y") )` is `false` and would continue the function, it also skipps the terminal prompt, which is good)

### Guidance to review
This hole statement debugging crushed my head. I used a simple script to test the different combinations. It should simplify the testing and review process if needed:
```ruby
def skip_no?(value)
  puts "would prompt terminal"
  value == 'n'
end

# play around with the vars
account_exists = false
talkative = true
skip = "y"

# new evaluation
result = ( account_exists && ( !talkative || !skip_no?(skip) ) )
puts result ? "would return\n\n" : "would continue\n\n"

# current evaluation
result = account_exists && !talkative || !skip_no?(skip)
puts result ? "would return\n\n" : "would continue\n\n"

```