### PR TITLE
Add large preview and download button to media library (Feature request #958)

### DIFF
--- a/app/assets/builds/spina/tailwind.css
+++ b/app/assets/builds/spina/tailwind.css
@@ -1806,6 +1806,10 @@ trix-editor [data-trix-mutable]::selection,
   margin-top: 0.5rem;
 }
 
+.ml-11 {
+  margin-left: 2.75rem;
+}
+
 .ml-1 {
   margin-left: 0.25rem;
 }
@@ -2054,6 +2058,10 @@ trix-editor [data-trix-mutable]::selection,
   max-width: 768px;
 }
 
+.max-w-screen-lg {
+  max-width: 1024px;
+}
+
 .max-w-5xl {
   max-width: 64rem;
 }
@@ -2152,6 +2160,10 @@ trix-editor [data-trix-mutable]::selection,
 .animate-spin {
   -webkit-animation: spin 1s linear infinite;
           animation: spin 1s linear infinite;
+}
+
+.cursor-zoom-in {
+  cursor: zoom-in;
 }
 
 .cursor-default {

--- a/app/assets/javascripts/spina/controllers/infinite_scroll_controller.js
+++ b/app/assets/javascripts/spina/controllers/infinite_scroll_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
 
   connect() {
     this.scrollElement.addEventListener("scroll", this.load.bind(this))
+    this.load() // Initial load
   }
 
   disconnect() {
@@ -18,6 +19,7 @@ export default class extends Controller {
       let top = this.buttonTarget.getBoundingClientRect().top
       if (top < window.innerHeight + 500) {
         this.buttonTarget.click()
+        this.buttonTarget.remove()
       }
     }
   }

--- a/app/components/spina/media_picker/image_component.html.erb
+++ b/app/components/spina/media_picker/image_component.html.erb
@@ -10,7 +10,7 @@
     data-deselected-class="border-transparent"
     class="w-full h-40 overflow-hidden rounded-md transform transition-transform duration-200 border-2 border-transparent hover:scale-105">
 
-    <%= image_tag helpers.thumbnail_url(@image), class: 'object-contain h-40 w-full', data: {controller: "image-fade-in"} %>
+    <%= image_tag helpers.large_thumbnail_url(@image), class: 'object-contain h-40 w-full', data: {controller: "image-fade-in"} %>
   </button>
 
   <div class="text-xs text-center text-gray-700 rounded p-1" data-selected-class="text-white bg-spina" data-deselected-class="text-gray-700"><%= @image.file.filename %></div>

--- a/app/components/spina/media_picker/modal_component.html.erb
+++ b/app/components/spina/media_picker/modal_component.html.erb
@@ -1,9 +1,9 @@
 <%= render(Spina::UserInterface::ModalComponent.new(size: "max-w-6xl h-full")) do |component| %>
   <div class="h-full w-full" data-controller="infinite-scroll media-picker-modal" data-target="<%= @target %>">
-    <turbo-frame id="media_picker">
+    <turbo-frame id="media_picker" data-action= "turbo:frame-load->infinite-scroll#load">
       <div class="flex flex-col md:flex-row h-full w-full">
         <div class="flex-1 bg-white flex flex-col max-h-full relative overflow-hidden">
-          <div data-infinite-scroll-target="container" data-controller="selectable" class="p-6 h-full w-full overflow-scroll ">
+          <div data-infinite-scroll-target="container" data-controller="selectable" class="p-6 h-full w-full overflow-scroll" data-action="scroll->infinite-scroll#load">
             
             <!-- Images are loaded using nested turbo-frame-tags -->
             <!-- Only load images in multiples of 4 so that this grid -->
@@ -14,8 +14,8 @@
               </div>
               
               <% if @images.next_page %>
-                <turbo-frame id="images-<%= @images.next_page %>">
-                  <%= link_to "...", helpers.path_to_next_page(@images), data: {infinite_scroll_target: "button"} %>
+                <turbo-frame id="images-<%= @images.next_page %>" data-action= "turbo:frame-load->infinite-scroll#load">
+                  <%= link_to "Load more images", helpers.path_to_next_page(@images), class: "btn btn-default mt-6", data: {infinite_scroll_target: "button"} %>
                 </turbo-frame>
               <% end %>
               

--- a/app/controllers/spina/admin/images_controller.rb
+++ b/app/controllers/spina/admin/images_controller.rb
@@ -5,7 +5,7 @@ module Spina
       before_action :set_breadcrumbs
 
       def index
-        @media_folders = MediaFolder.order(:name)
+        @media_folders = MediaFolder.order(:name).includes(:images)
         @images = Image.sorted.where(media_folder: @media_folder).with_attached_file.page(params[:page]).per(25)
       end
       
@@ -53,6 +53,7 @@ module Spina
         if @image.saved_change_to_media_folder_id?
           render :update
         else
+          @media_folders = MediaFolder.order(:name)
           render @image
         end
       end

--- a/app/controllers/spina/admin/images_controller.rb
+++ b/app/controllers/spina/admin/images_controller.rb
@@ -53,7 +53,7 @@ module Spina
         if @image.saved_change_to_media_folder_id?
           render :update
         else
-          redirect_to [:admin, @image]
+          render @image
         end
       end
 

--- a/app/helpers/spina/images_helper.rb
+++ b/app/helpers/spina/images_helper.rb
@@ -1,9 +1,24 @@
 module Spina
   module ImagesHelper
+  
+    def original_url(image)
+      return "" if image.nil?
+      main_app.url_for(image.file)
+    end
 
     def thumbnail_url(image)
       return "" if image.nil?
       main_app.url_for(image.variant(resize_to_fill: [400, 300]))
+    end
+    
+    def large_thumbnail_url(image)
+      return "" if image.nil?
+      main_app.url_for(image.variant(resize_to_fit: [800, 600]))
+    end
+    
+    def preview_url(image)
+      return "" if image.nil?
+      main_app.url_for(image.variant(resize_to_limit: [1600, 1200]))
     end
 
     def embedded_image_url(image)

--- a/app/views/spina/admin/images/_image.html.erb
+++ b/app/views/spina/admin/images/_image.html.erb
@@ -15,7 +15,7 @@
           <%=t 'spina.ui.rename' %>
         <% end %>
         
-        <% if Spina::MediaFolder.any? %>
+        <% if @media_folders.present? %>
           <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
             <% dropdown.button(classes: 'btn btn-default h-7 px-2 text-xs') do %>
               <%= heroicon('folder', style: :solid, class: 'w-4 h-4 mr-1 text-gray-600') %>
@@ -32,7 +32,7 @@
                   <% end %>
                 <% end %>
               <% end %>
-              <% Spina::MediaFolder.order(:name).each do |media_folder| %>
+              <% @media_folders.each do |media_folder| %>
                 <% if media_folder.id == image.media_folder_id %>
                   <%= render Spina::UserInterface::DropdownButtonComponent.new(disabled: true) do %>
                     <%= media_folder.name %>

--- a/app/views/spina/admin/images/_image.html.erb
+++ b/app/views/spina/admin/images/_image.html.erb
@@ -1,7 +1,9 @@
 <%= turbo_frame_tag dom_id(image) do %>
   <div class="flex items-center h-12 border-b border-gray-200 px-8 hover:bg-white group">
     <div class="w-8 mr-4 h-12 flex justify-center">
-      <%= image_tag thumbnail_url(image), class: "object-contain" %>
+      <%= link_to spina.admin_image_path(image), class: "flex items-center cursor-zoom-in", data: {turbo_frame: "modal"} do %>
+        <%= image_tag thumbnail_url(image), class: "object-contain" %>
+      <% end %>
     </div>
     
     <turbo-frame id="<%= dom_id(image) %>_filename" class="font-medium text-gray-800 h-full flex-1 w-56 text-sm flex items-center relative">
@@ -13,33 +15,35 @@
           <%=t 'spina.ui.rename' %>
         <% end %>
         
-        <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
-          <% dropdown.button(classes: 'btn btn-default h-7 px-2 text-xs') do %>
-            <%= heroicon('folder', style: :solid, class: 'w-4 h-4 mr-1 text-gray-600') %>
-            <%=t 'spina.ui.move_to' %>
-            <%= heroicon('chevron-down', style: :solid, class: 'w-4 h-4') %>
-          <% end %>
-          
-          <% dropdown.menu do %>
-            <% if image.media_folder_id.present? %>
-              <%= form_with model: image, url: spina.admin_image_path(image) do |f| %>
-                <%= f.hidden_field :media_folder_id, value: nil %>
-                <%= render Spina::UserInterface::DropdownButtonComponent.new do %>
-                  <%=t 'spina.media_library.no_folder' %>
+        <% if Spina::MediaFolder.any? %>
+          <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
+            <% dropdown.button(classes: 'btn btn-default h-7 px-2 text-xs') do %>
+              <%= heroicon('folder', style: :solid, class: 'w-4 h-4 mr-1 text-gray-600') %>
+              <%=t 'spina.ui.move_to' %>
+              <%= heroicon('chevron-down', style: :solid, class: 'w-4 h-4') %>
+            <% end %>
+            
+            <% dropdown.menu do %>
+              <% if image.media_folder_id.present? %>
+                <%= form_with model: image, url: spina.admin_image_path(image) do |f| %>
+                  <%= f.hidden_field :media_folder_id, value: nil %>
+                  <%= render Spina::UserInterface::DropdownButtonComponent.new do %>
+                    <%=t 'spina.media_library.no_folder' %>
+                  <% end %>
                 <% end %>
               <% end %>
-            <% end %>
-            <% Spina::MediaFolder.order(:name).each do |media_folder| %>
-              <% if media_folder.id == image.media_folder_id %>
-                <%= render Spina::UserInterface::DropdownButtonComponent.new(disabled: true) do %>
-                  <%= media_folder.name %>
-                <% end %>
-              <% else %>
-                <%= form_with model: image, url: spina.admin_image_path(image) do |f| %>
-                  <%= f.hidden_field :media_folder_id, value: media_folder.id %>
-                  
-                  <%= render Spina::UserInterface::DropdownButtonComponent.new do %>
+              <% Spina::MediaFolder.order(:name).each do |media_folder| %>
+                <% if media_folder.id == image.media_folder_id %>
+                  <%= render Spina::UserInterface::DropdownButtonComponent.new(disabled: true) do %>
                     <%= media_folder.name %>
+                  <% end %>
+                <% else %>
+                  <%= form_with model: image, url: spina.admin_image_path(image) do |f| %>
+                    <%= f.hidden_field :media_folder_id, value: media_folder.id %>
+                    
+                    <%= render Spina::UserInterface::DropdownButtonComponent.new do %>
+                      <%= media_folder.name %>
+                    <% end %>
                   <% end %>
                 <% end %>
               <% end %>
@@ -56,8 +60,12 @@
       </div>
     </div>
     <div class="text-gray-500 text-xs w-32 text-right whitespace-nowrap"><%=l image.created_at, format: :short %></div>
-    <div class="">
-      <%= button_to spina.admin_image_path(image), method: :delete, class: "block py-3 px-4 ml-2 text-gray-500 hover:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.images.delete_confirmation_html')}} do %>
+    <div class="flex items-center ml-2">
+      <%= link_to original_url(image), class: "block py-3 px-2 text-gray-500 hover:text-gray-900", download: image.file.filename do %>
+        <%= heroicon('download', class: 'w-5 h-5') %>
+      <% end %>
+      
+      <%= button_to spina.admin_image_path(image), method: :delete, class: "block py-3 px-2 text-gray-500 hover:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.images.delete_confirmation_html')}} do %>
         <%= heroicon('trash', class: "w-5 h-5") %>
       <% end %>
     </div>

--- a/app/views/spina/admin/images/index.html.erb
+++ b/app/views/spina/admin/images/index.html.erb
@@ -64,7 +64,7 @@
         
         <% if @images.next_page %>
           <%= turbo_frame_tag "images-#{@images.next_page}", data: {action: "turbo:frame-load->infinite-scroll#load"} do %>
-            <%= link_to t('spina.ui.load_more'), path_to_next_page(@images), class: 'hidden', data: {infinite_scroll_target: "button"} %>
+            <%= link_to t('spina.ui.load_more'), path_to_next_page(@images), class: "btn btn-default", data: {infinite_scroll_target: "button"} %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/spina/admin/images/show.html.erb
+++ b/app/views/spina/admin/images/show.html.erb
@@ -1,1 +1,3 @@
-<%= render @image %>
+<%= render Spina::UserInterface::ModalComponent.new(size: "max-w-screen-lg w-auto") do |modal| %>
+  <%= image_tag preview_url(@image) %>
+<% end %>

--- a/app/views/spina/admin/media_folders/_media_folder.html.erb
+++ b/app/views/spina/admin/media_folders/_media_folder.html.erb
@@ -11,8 +11,10 @@
     </div>
     <div class="text-gray-500 text-xs w-32 text-right"><%=l media_folder.created_at, format: :short %></div>
     
-    <%= button_to spina.admin_media_folder_path(media_folder), method: :delete, class: "block py-3 px-4 ml-2 text-gray-500 hover:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.media_library.media_folder_delete_confirmation_html')}} do %>
-      <%= heroicon('trash', class: 'w-5 h-5') %>
-    <% end %>
+    <div class="flex items-center ml-11">
+      <%= button_to spina.admin_media_folder_path(media_folder), method: :delete, class: "block py-3 px-2 text-gray-500 hover:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.media_library.media_folder_delete_confirmation_html')}} do %>
+        <%= heroicon('trash', class: 'w-5 h-5') %>
+      <% end %>
+    </div>
   </div>
 <% end %>


### PR DESCRIPTION
You can click an image thumbnail to open a fullscreen preview of that image. Also added a download button to download the original file.

<img width="1276" alt="CleanShot 2022-03-04 at 14 04 05@2x" src="https://user-images.githubusercontent.com/423116/156768421-5f4592e5-b214-4289-ace8-4b00966b3379.png">
