### PR TITLE
Addresses common namespace conflict for current_account method

### DIFF
--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -1,15 +1,15 @@
 module Spina
-  module CurrentAccount
+  module CurrentSpinaAccount
     extend ActiveSupport::Concern
     
     included do
-      before_action :current_account
-      helper_method :current_account
+      before_action :current_spina_account
+      helper_method :current_spina_account
     end
   
     private
     
-      def current_account
+      def current_spina_account
         Spina::Current.account ||= ::Spina::Account.first
       end
         

--- a/app/controllers/concerns/spina/current_theme.rb
+++ b/app/controllers/concerns/spina/current_theme.rb
@@ -10,7 +10,7 @@ module Spina
     private
     
       def current_theme
-        Spina::Current.theme ||= ::Spina::Theme.find_by_name(current_account.theme)
+        Spina::Current.theme ||= ::Spina::Theme.find_by_name(current_spina_account.theme)
       end
         
   end

--- a/app/controllers/concerns/spina/frontend.rb
+++ b/app/controllers/concerns/spina/frontend.rb
@@ -9,7 +9,7 @@ module Spina
       
       before_action :set_locale
       before_action :set_current_page
-      before_action :set_current_account
+      before_action :set_current_spina_account
     end
 
     def show
@@ -33,7 +33,7 @@ module Spina
         Spina::Current.page.view_context = view_context
       end
 
-      def set_current_account
+      def set_current_spina_account
         Spina::Current.account = Spina::Account.first
         Spina::Current.account.view_context = view_context
       end

--- a/app/controllers/spina/admin/accounts_controller.rb
+++ b/app/controllers/spina/admin/accounts_controller.rb
@@ -9,7 +9,7 @@ module Spina
       end
 
       def update
-        if current_account.update(account_params)
+        if current_spina_account.update(account_params)
           redirect_back fallback_location: spina.edit_admin_account_path, flash: {success: t('spina.accounts.saved')}
         else
           flash.now[:error] = t('spina.accounts.couldnt_be_saved')

--- a/app/controllers/spina/admin/admin_controller.rb
+++ b/app/controllers/spina/admin/admin_controller.rb
@@ -2,7 +2,7 @@ module Spina
   module Admin
     class AdminController < ActionController::Base
       include Spina.config.authentication.constantize
-      include Spina::CurrentAccount, Spina::CurrentTheme
+      include Spina::CurrentSpinaAccount, Spina::CurrentTheme
       
       helper Spina::Engine.helpers
       

--- a/app/controllers/spina/admin/layout_controller.rb
+++ b/app/controllers/spina/admin/layout_controller.rb
@@ -30,7 +30,7 @@ module Spina::Admin
       end
 
       def set_account
-        @account = current_account
+        @account = current_spina_account
       end
 
       def set_locale

--- a/app/controllers/spina/api/api_controller.rb
+++ b/app/controllers/spina/api/api_controller.rb
@@ -1,7 +1,7 @@
 module Spina
   module Api
     class ApiController < ActionController::Base
-      include Spina::CurrentAccount, Spina::CurrentTheme
+      include Spina::CurrentSpinaAccount, Spina::CurrentTheme
       
       protect_from_forgery unless: -> { request.format.json? }
       

--- a/app/controllers/spina/application_controller.rb
+++ b/app/controllers/spina/application_controller.rb
@@ -1,6 +1,6 @@
 class Spina::ApplicationController < Spina.frontend_parent_controller.constantize
   include Spina.config.authentication.constantize
-  include Spina::CurrentAccount, Spina::CurrentTheme
+  include Spina::CurrentSpinaAccount, Spina::CurrentTheme
   
   helper Spina::Engine.helpers
   

--- a/app/helpers/spina/pages_helper.rb
+++ b/app/helpers/spina/pages_helper.rb
@@ -28,7 +28,7 @@ module Spina
       Current.page
     end
 
-    def current_account
+    def current_spina_account
       Current.account
     end
 

--- a/app/views/spina/admin/accounts/edit.html.erb
+++ b/app/views/spina/admin/accounts/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: current_account, url: spina.admin_account_path do |f| %>
+<%= form_with model: current_spina_account, url: spina.admin_account_path do |f| %>
 
   <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
     <% header.actions do %>

--- a/docs/v2/themes/3_layout_parts.md
+++ b/docs/v2/themes/3_layout_parts.md
@@ -14,4 +14,4 @@ Just like adding parts to view_templates you can also add parts you want to use 
 end
 ```
 
-This content is stored on the `Spina::Account` model. You can use `current_account.content` to render layout parts in your frontend.
+This content is stored on the `Spina::Account` model. You can use `current_spina_account.content` to render layout parts in your frontend.

--- a/lib/generators/spina/templates/app/views/demo/pages/demo.html.erb
+++ b/lib/generators/spina/templates/app/views/demo/pages/demo.html.erb
@@ -9,9 +9,9 @@
   <%= content.image_tag :image, resize_to_fill: [100, 100] %>
 <% end %>
 
-<%= current_account.content :line %>
+<%= current_spina_account.content :line %>
 
-<% repeater current_account.content(:repeater) do |repeater_content| %>
+<% repeater current_spina_account.content(:repeater) do |repeater_content| %>
   <%= repeater_content.content :line %>
 <% end %>
 

--- a/lib/generators/spina/templates/app/views/layouts/default/application.html.erb
+++ b/lib/generators/spina/templates/app/views/layouts/default/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= current_account.name %></title>
+    <title><%= current_spina_account.name %></title>
     <%= csrf_meta_tags %>
   </head>
   <body>

--- a/lib/generators/spina/templates/app/views/layouts/demo/application.html.erb
+++ b/lib/generators/spina/templates/app/views/layouts/demo/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= current_account.name %></title>
+    <title><%= current_spina_account.name %></title>
     <%= csrf_meta_tags %>
   </head>
   <body>

--- a/test/dummy/app/views/demo/pages/demo.html.erb
+++ b/test/dummy/app/views/demo/pages/demo.html.erb
@@ -15,9 +15,9 @@
   <%= content.image_tag :image, resize_to_fill: [100, 100] %>
 <% end %>
 
-<%= current_account.content :line %>
+<%= current_spina_account.content :line %>
 
-<% repeater current_account.content(:repeater) do |repeater_content| %>
+<% repeater current_spina_account.content(:repeater) do |repeater_content| %>
   <%= repeater_content.content :line %>
 <% end %>
 

--- a/test/dummy/app/views/layouts/demo/application.html.erb
+++ b/test/dummy/app/views/layouts/demo/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= current_account.name %></title>
+    <title><%= current_spina_account.name %></title>
     <%= stylesheet_link_tag 'demo/application', media: 'all', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
   </head>

--- a/test/functional/spina/pages_controller_test.rb
+++ b/test/functional/spina/pages_controller_test.rb
@@ -5,7 +5,7 @@ module Spina
     setup do
       I18n.locale = :en
       @routes = Engine.routes
-      @current_account = FactoryBot.create :account
+      @current_spina_account = FactoryBot.create :account
     end
 
     test "visit homepage" do


### PR DESCRIPTION
We are implementing Spina into our existing Rails project.
We've come across a namespace conflict with the current_account method.

We've found its increasingly common to have current_user and current_account defined within the authentication model and Spina in using the same method name is causing us a conflict as we attempt to integrate Spina into our broader applications authentication.

To assist users to avoid this obvious potential conflict we'd like to offer that in spina, current_account be renamed to current_spina_account, freeing up the Account model to cause no conflicts in the clients main app.

We've created a pull request that makes this single change across the code base. All tests pass.
And the change is tested to be working in our app that integrates Spina.