### PR TITLE
Change current_account to current_spina_account, and add deprecation warning.

### DIFF
--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -5,17 +5,19 @@ module Spina
     included do
       before_action :current_spina_account
       helper_method :current_spina_account
-      helper_method :current_account unless Spina.disable_deprecated_methods
+      helper_method :current_account
     end
   
     private
 
-      def current_account
-        ActiveSupport::Deprecation.warn(
-          "#current_account is deprecated, due to a common authentication namespace conflict. \n" \
-          "Please use #current_spina_account instead."
-        )
-        current_spina_account
+      unless Spina.disable_deprecated_methods
+        def current_account
+          ActiveSupport::Deprecation.warn(
+            "#current_account is deprecated, due to a common authentication namespace conflict. \n" \
+            "Please use #current_spina_account instead."
+          )
+          current_spina_account
+        end
       end
 
       def current_spina_account

--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -5,10 +5,19 @@ module Spina
     included do
       before_action :current_spina_account
       helper_method :current_spina_account
+      helper_method :current_account
     end
   
     private
-    
+
+      def current_account
+        ActiveSupport::Deprecation.warn(
+          "#current_account is deprecated, due to a common authentication namespace conflict." \
+          "Please use #current_spina_account instead."
+        )
+        current_spina_account
+      end
+
       def current_spina_account
         Spina::Current.account ||= ::Spina::Account.first
       end

--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -1,15 +1,15 @@
 module Spina
-  module CurrentAccount
+  module CurrentSpinaAccount
     extend ActiveSupport::Concern
     
     included do
-      before_action :current_account
-      helper_method :current_account
+      before_action :current_spina_account
+      helper_method :current_spina_account
     end
   
     private
     
-      def current_account
+      def current_spina_account
         Spina::Current.account ||= ::Spina::Account.first
       end
         

--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -5,14 +5,14 @@ module Spina
     included do
       before_action :current_spina_account
       helper_method :current_spina_account
-      helper_method :current_account
+      helper_method :current_account unless Spina.disable_deprecated_methods
     end
   
     private
 
       def current_account
         ActiveSupport::Deprecation.warn(
-          "#current_account is deprecated, due to a common authentication namespace conflict." \
+          "#current_account is deprecated, due to a common authentication namespace conflict. \n" \
           "Please use #current_spina_account instead."
         )
         current_spina_account
@@ -21,6 +21,6 @@ module Spina
       def current_spina_account
         Spina::Current.account ||= ::Spina::Account.first
       end
-        
+      
   end
 end

--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -1,7 +1,7 @@
 module Spina
   module CurrentSpinaAccount
     extend ActiveSupport::Concern
-    
+
     included do
       before_action :current_spina_account
       helper_method :current_spina_account
@@ -10,19 +10,18 @@ module Spina
   
     private
 
-      unless Spina.disable_deprecated_methods
-        def current_account
-          ActiveSupport::Deprecation.warn(
-            "#current_account is deprecated, due to a common authentication namespace conflict. \n" \
-            "Please use #current_spina_account instead."
-          )
-          current_spina_account
-        end
-      end
+    def current_account
+      ActiveSupport::Deprecation.warn(
+        "#current_account is deprecated, due to a common authentication namespace conflict. \n" \
+        "Please use #current_spina_account instead."
+      )
+      current_spina_account
+    end
 
-      def current_spina_account
-        Spina::Current.account ||= ::Spina::Account.first
-      end
-      
+    def current_spina_account
+      Spina::Current.account ||= ::Spina::Account.first
+    end
+
+    remove_method :current_account if Spina.config.disable_current_account
   end
 end

--- a/app/controllers/concerns/spina/current_theme.rb
+++ b/app/controllers/concerns/spina/current_theme.rb
@@ -10,7 +10,7 @@ module Spina
     private
     
       def current_theme
-        Spina::Current.theme ||= ::Spina::Theme.find_by_name(current_account.theme)
+        Spina::Current.theme ||= ::Spina::Theme.find_by_name(current_spina_account.theme)
       end
         
   end

--- a/app/controllers/concerns/spina/frontend.rb
+++ b/app/controllers/concerns/spina/frontend.rb
@@ -9,7 +9,7 @@ module Spina
       
       before_action :set_locale
       before_action :set_current_page
-      before_action :set_current_account
+      before_action :set_current_spina_account
     end
 
     def show
@@ -33,7 +33,7 @@ module Spina
         Spina::Current.page.view_context = view_context
       end
 
-      def set_current_account
+      def set_current_spina_account
         Spina::Current.account = Spina::Account.first
         Spina::Current.account.view_context = view_context
       end

--- a/app/controllers/spina/admin/accounts_controller.rb
+++ b/app/controllers/spina/admin/accounts_controller.rb
@@ -9,7 +9,7 @@ module Spina
       end
 
       def update
-        if current_account.update(account_params)
+        if current_spina_account.update(account_params)
           redirect_back fallback_location: spina.edit_admin_account_path, flash: {success: t('spina.accounts.saved')}
         else
           flash.now[:error] = t('spina.accounts.couldnt_be_saved')

--- a/app/controllers/spina/admin/admin_controller.rb
+++ b/app/controllers/spina/admin/admin_controller.rb
@@ -2,7 +2,7 @@ module Spina
   module Admin
     class AdminController < ActionController::Base
       include Spina.config.authentication.constantize
-      include Spina::CurrentAccount, Spina::CurrentTheme
+      include Spina::CurrentSpinaAccount, Spina::CurrentTheme
       
       helper Spina::Engine.helpers
       

--- a/app/controllers/spina/admin/layout_controller.rb
+++ b/app/controllers/spina/admin/layout_controller.rb
@@ -30,7 +30,7 @@ module Spina::Admin
       end
 
       def set_account
-        @account = current_account
+        @account = current_spina_account
       end
 
       def set_locale

--- a/app/controllers/spina/api/api_controller.rb
+++ b/app/controllers/spina/api/api_controller.rb
@@ -1,7 +1,7 @@
 module Spina
   module Api
     class ApiController < ActionController::Base
-      include Spina::CurrentAccount, Spina::CurrentTheme
+      include Spina::CurrentSpinaAccount, Spina::CurrentTheme
       
       protect_from_forgery unless: -> { request.format.json? }
       

--- a/app/controllers/spina/application_controller.rb
+++ b/app/controllers/spina/application_controller.rb
@@ -1,6 +1,6 @@
 class Spina::ApplicationController < Spina.frontend_parent_controller.constantize
   include Spina.config.authentication.constantize
-  include Spina::CurrentAccount, Spina::CurrentTheme
+  include Spina::CurrentSpinaAccount, Spina::CurrentTheme
   
   helper Spina::Engine.helpers
   

--- a/app/helpers/spina/pages_helper.rb
+++ b/app/helpers/spina/pages_helper.rb
@@ -28,7 +28,7 @@ module Spina
       Current.page
     end
 
-    def current_account
+    def current_spina_account
       Current.account
     end
 

--- a/app/views/spina/admin/accounts/edit.html.erb
+++ b/app/views/spina/admin/accounts/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: current_account, url: spina.admin_account_path do |f| %>
+<%= form_with model: current_spina_account, url: spina.admin_account_path do |f| %>
 
   <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
     <% header.actions do %>

--- a/docs/v2/themes/3_layout_parts.md
+++ b/docs/v2/themes/3_layout_parts.md
@@ -14,4 +14,4 @@ Just like adding parts to view_templates you can also add parts you want to use 
 end
 ```
 
-This content is stored on the `Spina::Account` model. You can use `current_account.content` to render layout parts in your frontend.
+This content is stored on the `Spina::Account` model. You can use `current_spina_account.content` to render layout parts in your frontend.

--- a/lib/generators/spina/templates/app/views/demo/pages/demo.html.erb
+++ b/lib/generators/spina/templates/app/views/demo/pages/demo.html.erb
@@ -9,9 +9,9 @@
   <%= content.image_tag :image, resize_to_fill: [100, 100] %>
 <% end %>
 
-<%= current_account.content :line %>
+<%= current_spina_account.content :line %>
 
-<% repeater current_account.content(:repeater) do |repeater_content| %>
+<% repeater current_spina_account.content(:repeater) do |repeater_content| %>
   <%= repeater_content.content :line %>
 <% end %>
 

--- a/lib/generators/spina/templates/app/views/layouts/default/application.html.erb
+++ b/lib/generators/spina/templates/app/views/layouts/default/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= current_account.name %></title>
+    <title><%= current_spina_account.name %></title>
     <%= csrf_meta_tags %>
   </head>
   <body>

--- a/lib/generators/spina/templates/app/views/layouts/demo/application.html.erb
+++ b/lib/generators/spina/templates/app/views/layouts/demo/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= current_account.name %></title>
+    <title><%= current_spina_account.name %></title>
     <%= csrf_meta_tags %>
   </head>
   <body>

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -9,11 +9,11 @@ Spina.configure do |config|
   # Specify a backend path. Defaults to /admin.
   # config.backend_path = 'admin'
 
-  # Deprecated methods
+  # Deprecated current account method
   # ===============
-  # Uncomment the config below to disable all deprecated methods.
+  # Uncomment the config below to disable 'current_account'.
   # Use this if you are having a namespace conflict with the deprecated 'current_account' method.
-  # config.disable_deprecated_methods = true
+  # config.disable_current_account = true
   
   # Frontend routes
   # ===============

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -8,6 +8,12 @@ Spina.configure do |config|
   # ===============
   # Specify a backend path. Defaults to /admin.
   # config.backend_path = 'admin'
+
+  # Deprecated methods
+  # ===============
+  # Uncomment the config below to disable all deprecated methods.
+  # Use this if you are having a namespace conflict with the deprecated 'current_account' method.
+  # config.disable_deprecated_methods = true
   
   # Frontend routes
   # ===============

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -27,6 +27,7 @@ module Spina
                   :frontend_parent_controller,
                   :disable_frontend_routes,
                   :disable_decorator_load,
+                  :disable_deprecated_methods,
                   :locales, 
                   :embedded_image_size,
                   :mailer_defaults,
@@ -43,6 +44,7 @@ module Spina
   self.backend_path = 'admin'
   self.disable_frontend_routes = false
   self.disable_decorator_load = false
+  self.disable_deprecated_methods = false
   self.embedded_image_size = [2000, 2000]
   self.mailer_defaults = ActiveSupport::OrderedOptions.new
   self.thumbnail_image_size = [400, 400]

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -27,7 +27,7 @@ module Spina
                   :frontend_parent_controller,
                   :disable_frontend_routes,
                   :disable_decorator_load,
-                  :disable_deprecated_methods,
+                  :disable_current_account,
                   :locales, 
                   :embedded_image_size,
                   :mailer_defaults,
@@ -44,7 +44,7 @@ module Spina
   self.backend_path = 'admin'
   self.disable_frontend_routes = false
   self.disable_decorator_load = false
-  self.disable_deprecated_methods = false
+  self.disable_current_account = false
   self.embedded_image_size = [2000, 2000]
   self.mailer_defaults = ActiveSupport::OrderedOptions.new
   self.thumbnail_image_size = [400, 400]

--- a/test/dummy/app/views/demo/pages/demo.html.erb
+++ b/test/dummy/app/views/demo/pages/demo.html.erb
@@ -15,9 +15,9 @@
   <%= content.image_tag :image, resize_to_fill: [100, 100] %>
 <% end %>
 
-<%= current_account.content :line %>
+<%= current_spina_account.content :line %>
 
-<% repeater current_account.content(:repeater) do |repeater_content| %>
+<% repeater current_spina_account.content(:repeater) do |repeater_content| %>
   <%= repeater_content.content :line %>
 <% end %>
 

--- a/test/dummy/app/views/layouts/demo/application.html.erb
+++ b/test/dummy/app/views/layouts/demo/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= current_account.name %></title>
+    <title><%= current_spina_account.name %></title>
     <%= stylesheet_link_tag 'demo/application', media: 'all', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
   </head>

--- a/test/functional/spina/pages_controller_test.rb
+++ b/test/functional/spina/pages_controller_test.rb
@@ -5,7 +5,7 @@ module Spina
     setup do
       I18n.locale = :en
       @routes = Engine.routes
-      @current_account = FactoryBot.create :account
+      @current_spina_account = FactoryBot.create :account
     end
 
     test "visit homepage" do


### PR DESCRIPTION
I moved this to a new branch in my repo, and had to create a second PR.

current_account is now an alias of current_spina_account, and a deprecation warning has been added to it.

See #989 for old PR.