### PR TITLE
Fixes navigation bar to stop horizontal scrolling on mobile layout

### DIFF
--- a/app/views/spina/admin/shared/_navigation.html.erb
+++ b/app/views/spina/admin/shared/_navigation.html.erb
@@ -1,4 +1,4 @@
-<nav class="w-full md:max-w-xs bg-spina-dark md:bg-gradient-to-b from-spina-dark to-spina-light md:relative md:overflow-hidden" data-controller="navigation">
+<nav class="w-full md:max-w-xs bg-spina-dark md:bg-gradient-to-b from-spina-dark to-spina-light relative md:overflow-hidden" data-controller="navigation">
   <div class="flex flex-row md:flex-col justify-between h-full w-full bg-black p-1 md:p-3 bg-opacity-0 duration-300 ease-in-out transition-colors md:bg-opacity-50" data-navigation-target="primary">
 
     <ul class="flex md:flex-col">


### PR DESCRIPTION
When using Spina on a small screen, such as a mobile device, the menus were accessible off the side of the screen, by scrolling horizontally, which made for a poor user experience.

This change is very simple. The nav element had the "relative" tag set for size medium and up. Changing it to always be relative fixed this issue.

This change doesn't seem to impact any other part of the UI, as far as I can tell. Didn't bother to run tests on a 3 character change.
