### PR TITLE
Update Spina to v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Spina CMS Changelog
 
+## 2.9
+
+### 2.9.0 (March 15th, 2022)
+* Added translatable slugs for resources
+* Added large preview and download buttons to media library
+* Added missing German translations
+* Added active/current list item CSS to MenuPresenter
+* Fixed bug with infinite scrolling
+* Fixed bug with previewing translated pages
+* Fixed silent install generator
+* Fixed bug in render_404
+* Fixed CSS bugs
+* Updated documentation
+* Updated gem dependencies
+
 ## 2.8
 
 ### 2.8.1 (January 29nd, 2022)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina (2.8.1)
+    spina (2.9.0)
       ancestry
       attr_json
       babosa
@@ -154,7 +154,7 @@ GEM
       addressable (~> 2.7)
     letter_opener (1.8.0)
       launchy (>= 2.2, < 3)
-    loofah (2.14.0)
+    loofah (2.15.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -256,7 +256,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (4.0.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "2.8.1"
+  VERSION = "2.9.0"
 end


### PR DESCRIPTION
# Changelog

* Added translatable slugs for resources
* Added large preview and download buttons to media library
* Added missing German translations
* Added active/current list item CSS to MenuPresenter
* Fixed bug with infinite scrolling
* Fixed bug with previewing translated pages
* Fixed silent install generator
* Fixed bug in render_404
* Fixed CSS bugs
* Updated documentation
* Updated gem dependencies