### PR TITLE
fix HTML Parsing in RichTextPresenter

### DIFF
--- a/app/presenters/spina/rich_text_presenter.rb
+++ b/app/presenters/spina/rich_text_presenter.rb
@@ -20,7 +20,7 @@ module Spina
       end
     
       def render_embeds(html)
-        doc = Nokogiri::HTML(html)
+        doc = Nokogiri::HTML.fragment(html)
         doc.css(embed_selector).each do |node|
           node.replace render_embed(node.first_element_child)
         end


### PR DESCRIPTION
* nokogiri should parse the input html as fragment, not as hole document

### Context
While checking the syntax of the HTML document, I noticed that `<%= content.html :rich_text_part %>` parses an entire HTML document, and not just the relevant parts. This behavior is wrong and besides bad syntax it also has a negative impact on SEO. This PR fixes the behavior by having Nokogiri parse the input as HTML fragment rather than an entire document.

### Changes proposed in this pull request
Input:
```erb
<section>
  <%= content.html :rich_part %>
</section>
```
Output before PR:
```html
<section>
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<html>
  <body>
    <h2>....</h2>
    <!-- other content from "rich_part" -->
  </body>
</html>
</section>
```
Output after PR:
```html
<section>
  <h2>....</h2>
  <!-- other content from "rich_part" -->
</section>
```

### Guidance to review
