### PR TITLE
Update locales

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -13,6 +13,12 @@ de:
       spina/embeds/vimeo:
         url: vimeo.com/...
   activerecord:
+    errors:
+      models:
+        spina/page:
+          attributes:
+            title:
+              blank: Titel erforderlich
     attributes:
       spina/account:
         address: Adresse
@@ -277,6 +283,7 @@ de:
       save_draft: Entwurf speichern
       saved: Seite gespeichert
       saving: wird gespeichert...
+      couldnt_be_saved: Seite konnte nicht gespeichert werden
       search_engines: Suchmaschinen
       show_in_menu: unsichtbar
       skip_to_first_child: Zur ersten Unterseite weiterleiten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,12 @@ en:
       spina/embeds/vimeo:
         url: vimeo.com/...
   activerecord:
+    errors:
+      models:
+        spina/page:
+          attributes:
+            title:
+              blank: Title required
     attributes:
       spina/account:
         address: Address
@@ -270,6 +276,7 @@ en:
       save_draft: Save draft
       saved: Page saved
       saving: Saving...
+      couldnt_be_saved: Page couldn't be saved
       search_engines: Search engines
       show_in_menu: invisible
       skip_to_first_child: forward to first child page


### PR DESCRIPTION
* add translations for page edit with blank title (:de, :en)

### Context
Recently I noticed missing locales whilst trying to save a Page without Title.
