### PR TITLE
use title instead of name in page.to_s

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -47,7 +47,7 @@ module Spina
     translates :menu_title, :seo_title, :url_title, default: -> { title }
 
     def to_s
-      name
+      title
     end
 
     def page_id


### PR DESCRIPTION
Use title instead of name in page.to_s, because the presence of the title is required, while the presence of the name is not guaranteed

### Context
I have a Custom Part which references a Spina Page (Resource "Tags"). I use this Custom Part inside a Repeater. The Repeater uses the `to.s` function of the repeated Part to display a proper List on the left Column. Because the presence of the name on a Spina Page is not guaranteed, the List could not be displayed properly.

### Changes proposed in this pull request
Before the changes proposed in this PR:
![image](https://user-images.githubusercontent.com/39066612/161166471-400d3f5b-50e2-4bc6-8950-4fab54648f21.png)

After Changes:
![image](https://user-images.githubusercontent.com/39066612/161166403-5a2348d0-d277-4cc8-a4b5-a1811fa19901.png)


### Guidance to review
