### PR TITLE
Fallback to I18n.default_locale when not using Spina.config.locales

### DIFF
--- a/app/components/spina/pages/translations_component.rb
+++ b/app/components/spina/pages/translations_component.rb
@@ -24,7 +24,7 @@ module Spina
       private
   
         def spina_locales
-          Spina.config.locales.map(&:to_sym)
+          Spina.locales.map(&:to_sym)
         end
   
     end

--- a/app/components/spina/user_interface/translations_component.rb
+++ b/app/components/spina/user_interface/translations_component.rb
@@ -18,7 +18,7 @@ module Spina
       private
   
         def spina_locales
-          Spina.config.locales.map(&:to_sym)
+          Spina.locales.map(&:to_sym)
         end
   
     end

--- a/app/models/concerns/spina/translated_content.rb
+++ b/app/models/concerns/spina/translated_content.rb
@@ -6,7 +6,7 @@ module Spina
 
     included do  
       # Store each locale's content in [locale]_content as an array of parts
-      Spina.config.locales.each do |locale|
+      Spina.locales.each do |locale|
         attr_json "#{locale}_content".to_sym, AttrJson::Type::SpinaPartsModel.new, array: true, default: -> { [] }
         attr_json_setter_monkeypatch "#{locale}_content".to_sym
         attr_json_accepts_nested_attributes_for "#{locale}_content".to_sym

--- a/app/views/spina/sitemaps/show.xml.builder
+++ b/app/views/spina/sitemaps/show.xml.builder
@@ -7,7 +7,7 @@ xml.urlset "xmlns" => "http://www.google.com/schemas/sitemap/0.9", "xmlns:xhtml"
 
       # Translations
       page.translations.each do |translation|
-        if translation.locale.in? Spina.config.locales.map(&:to_s)
+        if translation.locale.in? Spina.locales.map(&:to_s)
           Mobility.with_locale(translation.locale) do
             xml.xhtml(:link, rel: "alternate", hreflang: translation.locale, href: "#{request.protocol}#{request.host}#{page.materialized_path}")
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,8 +92,8 @@ Spina::Engine.routes.draw do
     root to: "pages#homepage"
 
     # Pages
-    get '/:locale/*id' => 'pages#show', constraints: {locale: /#{Spina.config.locales.join('|')}/ }
-    get '/:locale/' => 'pages#homepage', constraints: {locale: /#{Spina.config.locales.join('|')}/ }
+    get '/:locale/*id' => 'pages#show', constraints: {locale: /#{Spina.locales.join('|')}/ }
+    get '/:locale/' => 'pages#homepage', constraints: {locale: /#{Spina.locales.join('|')}/ }
     get '/*id' => 'pages#show', as: "page", controller: 'pages', constraints: -> (request) {
       request.path.exclude?(ActiveStorage.routes_prefix) &&
       !(Rails.env.development? && request.path.starts_with?('/rails/'))

--- a/lib/generators/spina/templates/app/views/demo/shared/_languages.html.erb
+++ b/lib/generators/spina/templates/app/views/demo/shared/_languages.html.erb
@@ -1,5 +1,5 @@
-<% if Spina.config.locales.size > 1 %>
+<% if Spina.locales.size > 1 %>
   <div id="languages">
-    <%= Spina.config.locales.map{|l| link_to_unless(l == I18n.locale, l.upcase, root_url(params: {locale: l}))}.join(' / ').html_safe %>
+    <%= Spina.locales.map{|l| link_to_unless(l == I18n.locale, l.upcase, root_url(params: {locale: l}))}.join(' / ').html_safe %>
   </div>
 <% end %>

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -2,7 +2,8 @@ Spina.configure do |config|
   # Locales
   # ===============
   # All locales your content should be available in.
-  # config.locales = [I18n.default_locale]
+  # Defaults to I18n.default_locale
+  # config.locales = [:en, :nl]
 
   # Backend path
   # ===============

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -47,7 +47,7 @@ module Spina
   self.mailer_defaults = ActiveSupport::OrderedOptions.new
   self.thumbnail_image_size = [400, 400]
   self.frontend_parent_controller = "ApplicationController"
-  self.locales = [I18n.default_locale]
+  self.locales = []
   self.party_pooper = false
   self.transliterations = %i(latin)
   
@@ -98,6 +98,10 @@ module Spina
       end
       
       config_obj
+    end
+    
+    def locales
+      config.locales.presence || [I18n.default_locale]
     end
     
     def mounted_at

--- a/test/dummy/app/views/demo/shared/_languages.html.erb
+++ b/test/dummy/app/views/demo/shared/_languages.html.erb
@@ -1,5 +1,5 @@
-<% if Spina.config.locales.size > 1 %>
+<% if Spina.locales.size > 1 %>
 <div id="languages">
-  <%= Spina.config.locales.map{|l| link_to_unless(l == I18n.locale, l.upcase, root_url(params: {locale: l}))}.join(' / ').html_safe %>
+  <%= Spina.locales.map{|l| link_to_unless(l == I18n.locale, l.upcase, root_url(params: {locale: l}))}.join(' / ').html_safe %>
 </div>
 <% end %>


### PR DESCRIPTION
Our current default of `Spina.config.locales = [I18n.default_locale]` doesn't work. It's always `:en` because the initializer is loaded before the app can set a different default locale. This PR adds a new method `Spina.locales` which uses `Spina.config.locales`, but will fallback to `I18n.default_locale` as the default.