### PR TITLE
animated gif's can't have variants

### DIFF
--- a/app/models/spina/image.rb
+++ b/app/models/spina/image.rb
@@ -13,6 +13,7 @@ module Spina
     def variant(options)
       return "" unless file.attached?
       return file if file.content_type.include?('svg')
+      return file if file.content_type.include?('gif')
       return file unless file.variable?
 
       file.variant(options)

--- a/app/models/spina/parts/image.rb
+++ b/app/models/spina/parts/image.rb
@@ -17,7 +17,11 @@ module Spina
       end
 
       def svg?
-        filename =~ /\.svg\z/
+        (filename =~ /\.svg\z/).present?
+      end
+
+      def gif?
+        (filename =~ /\.gif\z/).present?
       end
 
       def spina_image
@@ -27,15 +31,15 @@ module Spina
       def present?
         signed_blob_id.present?
       end
-      
+
       def signed_id(expires_in: nil)
         signed_blob_id
       end
-      
+
       def variant(options)
         Spina::Parts::ImageVariant.new(self, options)
       end
-      
+
     end
   end
 end

--- a/app/presenters/spina/content_presenter.rb
+++ b/app/presenters/spina/content_presenter.rb
@@ -36,10 +36,10 @@ module Spina
     private
 
       def main_app_image_url(image, variant_options = {})
-        # SVG's can't have variants, 
+        # SVG's and animated GIF's can't have variants,
         # Render rails_service_blob_url directly instead
-        return view_context.main_app.url_for(image) if image.svg?
-        
+        return view_context.main_app.url_for(image) if image.svg? || image.gif?
+
         view_context.main_app.url_for(image.variant(variant_options))
       end
 


### PR DESCRIPTION
### Context
As an editor, I want to upload animated gifs to the media library, which are still animated when I display them in the frontend. According to [this link](https://stackoverflow.com/a/57250549/14826603), this is not possible with variants.

### Changes proposed in this pull request
Similar behavior is used for svgs, which are also not allowed to have variants. The behavior for gifs was added analogously.