### PR TITLE
Add customizable tailwind plugins

### DIFF
--- a/lib/generators/spina/templates/app/assets/config/spina/tailwind.config.js.tt
+++ b/lib/generators/spina/templates/app/assets/config/spina/tailwind.config.js.tt
@@ -1,7 +1,7 @@
 module.exports = {
   content: [
     <%= Spina.config.tailwind_content.map{|path|"'#{path}'"}.join(",\n") %>
-  ],  
+  ],
   theme: {
     fontFamily: {
       body: ['Metropolis'],
@@ -18,8 +18,6 @@ module.exports = {
     }
   },
   plugins: [
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/aspect-ratio'),
-    require('@tailwindcss/typography'),
+    <%= Spina.config.tailwind_plugins.map {|plugin|"require('#{plugin}')"}.join(",\n\t") %>
   ]
 }

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -22,17 +22,18 @@ module Spina
   config_accessor :api_key,
                   :api_path,
                   :authentication,
-                  :backend_path, 
+                  :backend_path,
                   :importmap,
                   :frontend_parent_controller,
                   :disable_frontend_routes,
                   :disable_decorator_load,
-                  :locales, 
+                  :locales,
                   :embedded_image_size,
                   :mailer_defaults,
                   :thumbnail_image_size,
                   :party_pooper,
                   :tailwind_content,
+                  :tailwind_plugins,
                   :queues,
                   :transliterations
 
@@ -47,20 +48,20 @@ module Spina
   self.mailer_defaults = ActiveSupport::OrderedOptions.new
   self.thumbnail_image_size = [400, 400]
   self.frontend_parent_controller = "ApplicationController"
-  self.locales = []
+  self.locales = [I18n.default_locale]
   self.party_pooper = false
   self.transliterations = %i(latin)
-  
+
   # Queues for background jobs
   # - config.queues.page_updates
   self.queues = ActiveSupport::InheritableOptions.new
-  
+
   # An importmap specifically meant for Spina
   self.importmap = Importmap::Map.new
-    
+
   # Tailwind content
-  # In order for Tailwind to generate all of the CSS Spina needs, 
-  # it needs to know about every single file in your project 
+  # In order for Tailwind to generate all of the CSS Spina needs,
+  # it needs to know about every single file in your project
   # that contains any Tailwind class names.
   # Make sure to add your own glob patterns if you're extending
   # Spina's UI.
@@ -70,43 +71,41 @@ module Spina
                            "#{Spina::Engine.root}/app/assets/javascripts/**/*.js",
                            "#{Spina::Engine.root}/app/**/application.tailwind.css"]
 
+  self.tailwind_plugins = %w[@tailwindcss/forms @tailwindcss/aspect-ratio @tailwindcss/typography]
+
   # Images that are embedded in the Trix editor are resized to fit
   # You can optimize this for your website and go for a smaller (or larger) size
   # Default: 2000x2000px
   class << self
     alias_method :config_original, :config
-    
+
     def config
       config_obj = self.config_original
-      
+
       def config_obj.tailwind_purge_content
         ActiveSupport::Deprecation.warn("config.tailwind_purge_content has been renamed to config.tailwind_content")
         tailwind_content
       end
-      
+
       def config_obj.tailwind_purge_content=(paths)
         ActiveSupport::Deprecation.warn("config.tailwind_purge_content has been renamed to config.tailwind_content")
         tailwind_content = paths
       end
-      
+
       def config_obj.embedded_image_size=(image_size)
         if image_size.is_a? String
           ActiveSupport::Deprecation.warn("Spina embedded_image_size should be set to an array of arguments to be passed to the :resize_to_limit ImageProcessing macro. https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit")
         end
-        
+
         self[:embedded_image_size] = image_size
       end
-      
+
       config_obj
     end
-    
-    def locales
-      config.locales.presence || [I18n.default_locale]
-    end
-    
+
     def mounted_at
       Spina::Engine.routes.find_script_name({})
     end
-    
+
   end
 end


### PR DESCRIPTION
### Context

I originally wrote this before realizing Spina only includes tailwind for its own admin interface, but I think this still holds value for any spina plugins that need to modify the available plugins.

### Changes proposed in this pull request

This change show allow modifying the plugins array generated by the tailwind rake class. Plugins are specified under the `tailwind_plugins` config key.
