### PR TITLE
Add actions to create Spina::Resource records

### DIFF
--- a/app/controllers/spina/admin/resources_controller.rb
+++ b/app/controllers/spina/admin/resources_controller.rb
@@ -1,17 +1,40 @@
+# frozen_string_literal: true
+
 module Spina
   module Admin
     class ResourcesController < AdminController
       before_action :set_locale
       before_action :set_resource, only: [:edit, :update]
 
-      def edit        
-        add_breadcrumb @resource.label, spina.admin_pages_path(resource_id: @resource.id), class: 'text-gray-400'
-        add_breadcrumb t('spina.edit')
+      def new
+        add_breadcrumb I18n.t("spina.resources.new")
+        @resource = Resource.new
+      end
+
+      def index
+        add_breadcrumb I18n.t("spina.website.resources"), spina.admin_resources_path
+        @resources = Resource.all
+      end
+
+      def create
+        @resource = Resource.new(resource_params)
+
+        if Mobility.with_locale(@locale) { @resource.save }
+          flash[:success] = t("spina.resources.saved")
+          redirect_to spina.admin_pages_path(resource_id: @resource.id)
+        else
+          render :new
+        end
+      end
+
+      def edit
+        add_breadcrumb @resource.label, spina.admin_pages_path(resource_id: @resource.id), class: "text-gray-400"
+        add_breadcrumb t("spina.edit")
       end
 
       def update
         if Mobility.with_locale(@locale) { @resource.update(resource_params) }
-          flash[:success] = t('spina.resources.saved')
+          flash[:success] = t("spina.resources.saved")
           redirect_to spina.admin_pages_path(resource_id: @resource.id)
         else
           render :edit
@@ -20,17 +43,18 @@ module Spina
 
       private
 
-        def resource_params
-          params.require(:resource).permit(:label, :slug, :view_template, :order_by, :parent_page_id)
-        end
+      def resource_params
+        params.require(:resource)
+          .permit(:label, :name, :slug, :view_template, :order_by, :parent_page_id)
+      end
 
-        def set_resource
-          @resource = Resource.find(params[:id])          
-        end
+      def set_resource
+        @resource = Resource.find(params[:id])
+      end
 
-        def set_locale
-          @locale = params[:locale] || I18n.default_locale
-        end
+      def set_locale
+        @locale = params[:locale] || I18n.default_locale
+      end
 
     end
   end

--- a/app/controllers/spina/admin/resources_controller.rb
+++ b/app/controllers/spina/admin/resources_controller.rb
@@ -37,6 +37,8 @@ module Spina
           flash[:success] = t("spina.resources.saved")
           redirect_to spina.admin_pages_path(resource_id: @resource.id)
         else
+          add_breadcrumb @resource.label, spina.admin_pages_path(resource_id: @resource.id), class: "text-gray-400"
+          add_breadcrumb t("spina.edit")
           render :edit
         end
       end

--- a/app/models/spina/resource.rb
+++ b/app/models/spina/resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spina
   class Resource < ApplicationRecord
     extend Mobility
@@ -7,6 +9,9 @@ module Spina
     after_commit :update_resource_pages, on: [:update]
 
     translates :slug, backend: :jsonb
+
+    validates :label,
+      presence: {allow_blank: false}
 
     def pages
       case order_by
@@ -24,7 +29,7 @@ module Spina
         ResourcePagesUpdateJob.perform_later(id)
       end
     end
-    
+
     def order_by_options
       [
         [Spina::Page.human_attribute_name(:title), "title"], 

--- a/app/views/spina/admin/resources/_form.html.erb
+++ b/app/views/spina/admin/resources/_form.html.erb
@@ -1,0 +1,60 @@
+<%= form_with model: [spina, :admin, resource], id: dom_id(resource) do |f| %>
+  <%= hidden_field_tag :locale, locale %>
+
+  <div class="grid grid-cols-3 gap-x-12">
+    <div class="col-span-1">
+      <%= label_tag :name, class: "font-medium block" do %>
+        <%= Spina::Resource.human_attribute_name(:name) %>
+      <% end %>
+      <div class="text-gray-600 text-sm"><%=t 'spina.resources.name_description' %></div>
+    </div>
+
+    <div class="col-span-2">
+      <%= render Spina::Forms::TextFieldComponent.new(f, :name, size: "lg", autofocus: resource.name.blank?) %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-3 gap-x-12 mt-3">
+    <div class="col-span-1">
+      <%= label_tag :label, class: "font-medium block" do %>
+        <%= Spina::Resource.human_attribute_name(:label) %>
+      <% end %>
+      <div class="text-gray-600 text-sm"><%=t 'spina.resources.label_description' %></div>
+    </div>
+
+    <div class="col-span-2">
+      <%= render Spina::Forms::TextFieldComponent.new(f, :label, size: "lg", autofocus: resource.label.blank?) %>
+    </div>
+  </div>
+
+  <div class="border-t border-gray-200 my-6"></div>
+
+  <div class="grid grid-cols-3 gap-x-12">
+    <div class="col-span-1">
+      <%= label_tag :label, class: "font-medium block" do %>
+        <%= Spina::Resource.human_attribute_name(:settings) %>
+      <% end %>
+      <div class="text-gray-600 text-sm"><%=t 'spina.resources.settings_description' %></div>
+    </div>
+
+    <div class="col-span-2">
+      <%= f.label :slug, class: 'font-medium text-sm text-gray-700 block' %>
+
+      <% Mobility.with_locale(locale) do %>
+        <%= render Spina::Forms::TextFieldComponent.new(f, :slug) %>
+      <% end %>
+
+      <div class="mt-5">
+        <%= f.label :view_template, class: 'font-medium text-sm text-gray-700 block' %>
+
+        <% options = options_for_select(current_theme.view_templates.map { |template| [template[:title], template[:name]] }, resource.view_template) %>
+        <%= f.select :view_template, options, {include_blank: t('spina.resources.no_default_template')}, class: 'form-select', data: {controller: "select-placeholder", action: "select-placeholder#update"} %>
+      </div>
+
+      <div class="mt-5">
+        <%= f.label :order_by, class: 'font-medium text-sm text-gray-700 block' %>
+        <%= f.select :order_by, f.object.order_by_options, {include_blank: t('spina.resources.manual_sorting')}, class: 'form-select' %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spina/admin/resources/index.html.erb
+++ b/app/views/spina/admin/resources/index.html.erb
@@ -1,0 +1,30 @@
+<%= render Spina::UserInterface::HeaderComponent.new do |header| %>
+  <% header.actions do %>
+    <%= link_to spina.new_admin_resource_path, class: "btn btn-primary" do %>
+      <%= heroicon("plus", style: :solid, class: "w-7 h-7 -ml-2") %>
+      <%= t("spina.resources.new") %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%- if @resources.any? %>
+
+  <div class="my-6 md:m-8 bg-white md:rounded-lg border-l-0 border-r-0 border md:border-r md:border-l border-gray-200 border-b-0 shadow-sm">
+    <ul class="resource--list">
+      <%- @resources.each do |resource| %>
+        <li data-id="<%= resource.id %>">
+          <%= link_to spina.edit_admin_resource_path(resource), class: "block text-spina font-medium text-sm p-4 hover:text-spina-dark" do %>
+            <%= resource.label %>
+
+            <small class="font-normal inline-block pl-4"><%= resource.name %></small>
+          <% end %>
+        </li>
+      <% end -%>
+    </ul>
+  </div>
+
+<% else %>
+
+  <div class="m-8 my-6 italic text-gray-400"><%=t 'spina.resources.no_resources_yet' %></div>
+
+<% end -%>

--- a/app/views/spina/admin/resources/new.html.erb
+++ b/app/views/spina/admin/resources/new.html.erb
@@ -1,7 +1,5 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
   <% header.actions do %>
-    <%= render Spina::UserInterface::TranslationsComponent.new(@resource, label: @locale.upcase) %>
-
     <%= button_tag type: :submit, form: dom_id(@resource), class: 'btn btn-primary', data: {controller: "button", action: "button#loading", loading_message: t('spina.ui.saving')} do %>
       <%= heroicon('check', style: :solid, class: 'w-5 h-5 mr-1 -ml-2') %>
       <%=t 'spina.ui.save_changes' %>

--- a/app/views/spina/admin/shared/_navigation.html.erb
+++ b/app/views/spina/admin/shared/_navigation.html.erb
@@ -6,32 +6,34 @@
         <% nav.icon do %>
           <%= heroicon('document-text', style: :solid, class: 'hidden md:block w-8 h-8 text-white md:mr-3') %>
           <%= heroicon('menu', style: :solid, class: 'md:hidden w-8 h-8 text-white md:mr-3') %>
-          
+
           <div class="text-white font-semibold hidden md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all" data-navigation-target="label">
             <%= t('spina.website.content') %>
           </div>
         <% end %>
 
         <% nav.links do %>
-        
-          <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.pages'), spina.admin_pages_path, active: controller_name.in?(%w(pages resources)) %>
-          
+
+          <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.resources'), spina.admin_resources_path, active: controller_name.in?(%w(resources)) %>
+
+          <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.pages'), spina.admin_pages_path, active: controller_name.in?(%w(pages)) %>
+
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.navigations.navigations'), spina.admin_navigations_path, active: controller_name == "navigations" %>
 
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.layout.layout'), spina.edit_admin_layout_path, active: controller_name == "layout" %>
-          
+
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.media_library'), spina.admin_images_path, active: controller_name.in?(%w(images media_folders attachments)) %>
-          
+
           <%= render Spina::Hooks::HookComponent.new(partial: "website_secondary_navigation") %>
         <% end %>
       <% end %>
-      
+
       <%= render Spina::Hooks::HookComponent.new(partial: "primary_navigation") %>
 
       <%= render Spina::MainNavigation::SubNavComponent.new(:settings) do |nav| %>
         <% nav.icon do %>
           <%= heroicon('cog', style: :solid, class: 'w-8 h-8 text-white md:mr-3') %>
-          
+
           <div class="text-white font-semibold hidden md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all" data-navigation-target="label">
             <%= t('spina.website.settings') %>
           </div>
@@ -44,15 +46,15 @@
           <% if Spina.config.authentication == "Spina::Authentication::Sessions" %>
             <%= render Spina::MainNavigation::LinkComponent.new(t('spina.settings.users'), spina.admin_users_path, active: controller_name == "users") %>
           <% end %>
-          
+
           <%= render Spina::Hooks::HookComponent.new(partial: "settings_secondary_navigation") %>
-          
+
           <% Spina::Plugin.all.each do |plugin| %>
             <% if plugin.settings.present? %>
               <%= render Spina::MainNavigation::LinkComponent.new(t("spina.#{plugin.namespace}.title"), spina.admin_edit_settings_path(plugin.namespace), active: controller_name == 'settings' && params[:plugin] == plugin.namespace) %>
             <% end %>
           <% end %>
-          
+
         <% end %>
       <% end %>
     </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,6 +325,9 @@ en:
       edit: Edit resource
       label_description: User-facing label for this page collection.
       manual_sorting: Manual sorting
+      name_description: Internal label for this page collection.
+      name: Name
+      new: New collection
       no_default_template: No default template
       saved: Page collection saved
       settings: "%{label} settings"
@@ -388,6 +391,7 @@ en:
       pages: Pages
       pages_description: All pages on your website
       photos: Images
+      resources: Collections
       settings: Settings
       theme: Theme
       title: Your website

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -294,6 +294,9 @@ es:
       edit: Editar recurso
       label_description: User-facing label for this page collection.
       manual_sorting: Ordenamiento manual
+      name_description: Nombre interno para esta colección de páginas.
+      name: Nombre
+      new: Nueva colección
       no_default_template: No hay plantilla por defecto
       saved: Colección de páginas guardadas
       settings: "%{label} configuraciones"
@@ -342,6 +345,9 @@ es:
       pages: Páginas
       pages_description: Todas las páginas de tu sitio
       photos: Imágenes
+      resources: Colecciones
+      settings: Ajustes
+      theme: Tema
       title: Tu sitio
     wysiwyg:
       heading_1: Encabezado 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 end
 
 Spina::Engine.routes.draw do
-  
+
   # API
   namespace :api, path: Spina.config.api_path do
     resources :pages, only: [:index, :show]
@@ -33,7 +33,7 @@ Spina::Engine.routes.draw do
     patch "/settings/:plugin", to: "settings#update", as: :settings
 
     resources :users
-    
+
     # Sessions
     resources :sessions
     get "login" => "sessions#new"
@@ -48,7 +48,7 @@ Spina::Engine.routes.draw do
         get :edit_template
         get :children
       end
-      
+
       resource :move, controller: "move_pages"
 
       post :sort, on: :collection
@@ -57,7 +57,7 @@ Spina::Engine.routes.draw do
     resources :parent_pages
     resource :layout, controller: :layout, only: [:edit, :update]
 
-    resources :resources, only: [:show, :edit, :update]
+    resources :resources, except: [:destroy]
 
     resources :navigations do
       post :sort, on: :member
@@ -79,9 +79,9 @@ Spina::Engine.routes.draw do
     end
 
     resources :images
-    
+
     resource :media_picker, controller: "media_picker", only: [:show]
-    
+
     resources :embeds, only: [:new, :create]
   end
 


### PR DESCRIPTION
## Context

I started using Spina locally and noticed the "collections" model is cryptic. It's required to create new pages but as an user I didn't get any introduction nor instructions on how they work nor why they work as they do.

## Changes proposed in this pull request

* Add navigation links to add new resources/collections (see #1045)
* Add `name` field to `Spina::Resource` form

## Screenshots

![image](https://user-images.githubusercontent.com/9020659/175749385-ccfec211-96b5-4369-b851-bf8c36e3edce.png)

![image](https://user-images.githubusercontent.com/9020659/175749405-a4557312-4fee-41ad-995d-e08bab0eb005.png)

