### PR TITLE
Fix small bug for installing spina

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Run the installer to start the setup process:
 
     rails g spina:install [--silent] [--first-deploy]
 
+Run the installer to start the setup process if any error occurred for the above command or if you have an existing project:
+    rails spina:install
+
 The installer will help you create your first user interactively, unless you choose the optional `--silent` flag : in this case, defaults will apply.
 
 Then start `rails s` and access Spina at `/admin`.


### PR DESCRIPTION
Found a small bug while I was installing the spinaCMS.

The bug was as follows when I was using the command `rails g spina:install` (it throws the Mobility error)
```
/home/shubharthak/.rvm/gems/ruby-3.1.2/gems/mobility-1.2.9/lib/mobility.rb:133:in `translations_class': Mobility has not been configured. Configure with Mobility.configure, or assign a translations class with Mobility.translates_with(<class>) (Mobility::Error)
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/mobility-1.2.9/lib/mobility.rb:98:in `translates'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/spina-2.10.0/app/models/spina/resource.rb:9:in `<class:Resource>'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/spina-2.10.0/app/models/spina/resource.rb:2:in `<module:Spina>'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/spina-2.10.0/app/models/spina/resource.rb:1:in `<main>'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:27:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/helpers.rb:95:in `const_get'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/helpers.rb:95:in `cget'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:237:in `block (2 levels) in eager_load'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/helpers.rb:26:in `block in ls'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/helpers.rb:18:in `each_child'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/helpers.rb:18:in `ls'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:232:in `block in eager_load'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:217:in `synchronize'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:217:in `eager_load'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:317:in `each'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:317:in `eager_load_all'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/application/finisher.rb:74:in `block in <module:Finisher>'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/initializable.rb:32:in `instance_exec'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/initializable.rb:32:in `run'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:228:in `block in tsort_each'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:347:in `each'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:347:in `call'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:347:in `each_strongly_connected_component'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:226:in `tsort_each'
	from /home/shubharthak/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/tsort.rb:205:in `tsort_each'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/initializable.rb:60:in `run_initializers'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/application.rb:372:in `initialize!'
	from /home/shubharthak/Desktop/curve_tomorrow/rails-base/config/environment.rb:5:in `<main>'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/application.rb:348:in `require_environment!'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/command/actions.rb:28:in `require_environment!'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/commands/generate/generate_command.rb:21:in `perform'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/command/base.rb:87:in `perform'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/command.rb:48:in `invoke'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/railties-7.0.3/lib/rails/commands.rb:18:in `<main>'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /home/shubharthak/.rvm/gems/ruby-3.1.2/gems/bootsnap-1.11.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
```
While the command should be `rails spina:install` 