### PR TITLE
Fix /admin/navigations by not running callback on unused action

### DIFF
--- a/app/controllers/spina/admin/navigations_controller.rb
+++ b/app/controllers/spina/admin/navigations_controller.rb
@@ -2,7 +2,7 @@ module Spina
   module Admin
     class NavigationsController < AdminController
       before_action :set_breadcrumb
-      before_action :set_navigation, only: [:show, :edit, :update]
+      before_action :set_navigation, only: [:edit, :update]
       
       admin_section :content
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Spina::Engine.routes.draw do
 
     resources :resources, only: [:show, :edit, :update]
 
-    resources :navigations do
+    resources :navigations, only: [:index, :edit, :update] do
       post :sort, on: :member
       resources :navigation_items
     end


### PR DESCRIPTION
Was getting `The show action could not be found for the :set_navigation callback on Spina::Admin::NavigationsController, but it is listed in its :only option` in a fresh application when visiting /admin/navigations.
