### PR TITLE
Add inline file upload to attachment part

### DIFF
--- a/app/controllers/spina/admin/attachments_controller.rb
+++ b/app/controllers/spina/admin/attachments_controller.rb
@@ -30,6 +30,11 @@ module Spina
         end
       end
       
+      def inline_upload
+        @attachment = Attachment.create(attachment_params)
+        render turbo_stream: turbo_stream.append(params[:select_id], partial: "parts/attachments/attachment", object: @attachment)
+      end
+      
       def update
         @attachment = Attachment.find(params[:id])
         old_signed_id = @attachment.file&.blob&.signed_id
@@ -62,7 +67,7 @@ module Spina
       end
 
       def attachment_params
-        params.require(:attachment).permit(:file, :page_id, :_destroy)
+        params.require(:attachment).permit(:file, :_destroy)
       end
     end
   end

--- a/app/views/spina/admin/parts/attachments/_attachment.html.erb
+++ b/app/views/spina/admin/parts/attachments/_attachment.html.erb
@@ -1,0 +1,3 @@
+<option value="<%= attachment.id %>" signed-blob-id="<%= attachment.file&.blob&.signed_id %>" filename="<%= attachment.file&.filename %>" selected>
+  <%= attachment.file&.filename %>
+</option>

--- a/app/views/spina/admin/parts/attachments/_form.html.erb
+++ b/app/views/spina/admin/parts/attachments/_form.html.erb
@@ -5,5 +5,26 @@
   <%= f.hidden_field :signed_blob_id, data: {attachment_picker_target: 'signedBlobId'} %>
   <%= f.hidden_field :filename, data: {attachment_picker_target: 'filename'} %>
 
-  <%= f.select :attachment_id, Spina::Attachment.sorted.map{|attachment| [attachment.file&.filename, attachment.id, data: {signed_blob_id: attachment.file&.blob&.signed_id, filename: attachment.file&.filename}]}, {include_blank: t("spina.attachments.choose_attachment")}, {class: "form-select mt-1", data: {action: "attachment-picker#pick"}} %>
+  <div class="flex items-center space-x-3 mt-1">
+    <% select_id = dom_id(f.object, f.object.object_id) %>
+    
+    <%= f.select :attachment_id, Spina::Attachment.sorted.map{|attachment| [attachment.file&.filename, attachment.id, data: {signed_blob_id: attachment.file&.blob&.signed_id, filename: attachment.file&.filename}]}, {include_blank: t("spina.attachments.choose_attachment")}, {id: select_id, class: "form-select", data: {action: "attachment-picker#pick"}} %>
+    
+    <div class="text-gray-400 font-medium text-sm">
+      <%=t 'spina.ui.or' %>
+    </div>
+    
+    <%= form_with model: [:admin, Spina::Attachment.new], url: spina.inline_upload_admin_attachments_path, data: {controller: "form loading-button", loading_message: t('spina.media_library.uploading'), action: "turbo:submit-end->loading-button#doneLoading"} do |f| %>
+      <%= hidden_field_tag :select_id, select_id %>
+      <% file_field_id = "file_#{f.object.object_id}" %>
+      
+      <%= f.file_field :file, id: file_field_id, class: 'hidden', data: {action: "loading-button#loading form#requestSubmit"} %>
+      
+      <button type="button" class="btn btn-default" data-controller="delegate-click" data-action="delegate-click#click" data-loading-button-target="button" data-delegate-click-target="#<%= file_field_id %>">
+        <%= heroicon("upload", style: :solid, class: "w-4 h-4 -ml-1 mr-1") %>
+        <%=t 'spina.attachments.upload_one' %>
+      </button>
+    <% end %>
+
+  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,7 @@ en:
       insert: Insert document
       insert_multiple: Insert documents
       upload: Upload files
+      upload_one: Upload file
     cancel: Cancel
     choose_from_library: Choose from library
     close: Close
@@ -348,6 +349,7 @@ en:
       move_to: Move to
       new_entry: New entry
       optional: Optional
+      or: or
       rename: Rename
       replace: Replace
       save_changes: Save changes

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -108,7 +108,8 @@ nl:
       delete_confirmation_html: Weet je het zeker? Het kan zijn dat dit document in gebruik is op een pagina.
       insert: Document toevoegen
       insert_multiple: Documenten toevoegen
-      upload: 
+      upload: Upload documenten
+      upload_one: Upload document
     cancel: Annuleren
     choose_from_library: Kies uit bibliotheek
     close: Sluiten
@@ -319,6 +320,7 @@ nl:
       move_to: Verplaats naar
       new_entry: Nieuw item
       optional: Optioneel
+      or: of
       rename: Hernoemen
       replace: Vervangen
       save_changes: Wijzigingen opslaan

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,12 +66,7 @@ Spina::Engine.routes.draw do
     end
 
     resources :attachments do
-      collection do
-        get 'select/:page_part_id' => 'attachments#select', as: :select
-        post 'insert/:page_part_id' => 'attachments#insert', as: :insert
-        get 'select_collection/:page_part_id' => 'attachments#select_collection', as: :select_collection
-        post 'insert_collection/:page_part_id' => 'attachments#insert_collection', as: :insert_collection
-      end
+      post :inline_upload, on: :collection
     end
     resources :rename_files
 

--- a/test/dummy/config/initializers/themes/default.rb
+++ b/test/dummy/config/initializers/themes/default.rb
@@ -8,6 +8,10 @@
     title:      'Text',
     hint:       'Your main content',
     part_type:  'Spina::Parts::Text'
+  }, {
+    name: 'attachment',
+    title: "Attachment",
+    part_type: "Spina::Parts::Attachment"
   }]
 
   theme.view_templates = [{
@@ -19,7 +23,7 @@
     title:        'Default',
     description:  'A simple page',
     usage:        'Use for your content',
-    parts:        ['text']
+    parts:        ['text', 'attachment']
   }]
 
   theme.custom_pages = [{


### PR DESCRIPTION
Adds a button to the `Spina::Parts::Attachment` form so you can directly upload new files.

<img width="547" alt="CleanShot 2022-10-07 at 12 43 21@2x" src="https://user-images.githubusercontent.com/423116/194535649-8b173480-f0f4-483a-97d2-2d836d02383d.png">
