### PR TITLE
Deprecate the use of app/decorators

### DIFF
--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -20,9 +20,9 @@ module Spina
     config.autoload_paths += %W( #{config.root}/lib )
 
     config.to_prepare do
-      # Require decorators from main application
       unless Spina.config.disable_decorator_load
         Dir.glob(Rails.root + "app/decorators/**/*_decorator.rb").each do |decorator|
+          ActiveSupport::Deprecation.warn("using app/decorators is deprecated in favor of app/overrides. Read more about overriding Spina at spinacms.com/guides")
           require_dependency(decorator)
         end
       end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -7,16 +7,17 @@ require "spina"
 
 module Dummy
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
     config.hosts << "dummy.puma"
     config.hosts << "dummy.test"
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    
+    overrides = "#{Rails.root}/app/overrides"
+    Rails.autoloaders.main.ignore(overrides)
+    config.to_prepare do
+      Dir.glob("#{overrides}/**/*_override.rb").each do |override|
+        load override
+      end
+    end
   end
 end
-


### PR DESCRIPTION
Instead of using `app/decorators` and requiring those files from the engine, I propose we follow the [Rails Guides](https://guides.rubyonrails.org/engines.html#overriding-models-and-controllers) and switch to a different setup to override the engine's functionality.

I wrote a small guide about how to best override Spina's classes and methods: [Overriding Spina](https://spinacms.com/guides/plugins/overriding-spina)