### PR TITLE
Add option to add different layout to view_templates

### DIFF
--- a/app/controllers/concerns/spina/frontend.rb
+++ b/app/controllers/concerns/spina/frontend.rb
@@ -78,7 +78,22 @@ module Spina
       end
 
       def render_with_template(page)
-        render layout: "#{current_theme.name.parameterize.underscore}/#{page.layout_template || 'application'}", template: "#{current_theme.name.parameterize.underscore}/pages/#{Spina::Current.page.view_template || 'show'}"
+        render layout: "#{current_theme.name.parameterize.underscore}/#{layout_template_for_page(page)}", template: "#{current_theme.name.parameterize.underscore}/pages/#{view_template_for_page(page)}"
+      end
+      
+      def view_template_for_page(page)
+        page.view_template.presence || "show"
+      end
+      
+      def layout_template_for_page(page)
+        return page.layout_template if page.layout_template.present?
+        view_template_config(page)[:layout].presence || "application"
+      end
+
+      def view_template_config(page)
+        current_theme.view_templates.find do |template|
+          template[:name] == view_template_for_page(page)
+        end
       end
 
   end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -98,11 +98,6 @@ module Spina
       super + "_" + Mobility.locale.to_s
     end
 
-    def view_template_config(theme)
-      view_template_name = view_template.presence || 'show'
-      theme.view_templates.find { |template| template[:name] == view_template_name }
-    end
-
     private
 
       def set_default_position

--- a/test/dummy/app/views/demo/pages/different_layout.html.erb
+++ b/test/dummy/app/views/demo/pages/different_layout.html.erb
@@ -1,0 +1,1 @@
+View template with a different layout

--- a/test/dummy/app/views/layouts/demo/different_layout.html.erb
+++ b/test/dummy/app/views/layouts/demo/different_layout.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= current_spina_account.name %></title>
+    <%= stylesheet_link_tag 'demo/application', media: 'all', 'data-turbolinks-track' => true %>
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+    <%= render 'demo/shared/languages' %>
+    <%= render 'demo/shared/navigation' %>
+    ohi
+    This is a different layout
+    
+    <%= yield %>
+  </body>
+</html>

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -86,6 +86,11 @@ Spina::Theme.register do |theme|
     description: 'Article template',
     parts: ['body'],
     exclude_from: %w(main)
+  }, {
+    name: 'different_layout',
+    title: "Different layout",
+    parts: %w(body),
+    layout: 'different_layout'
   }]
 
   theme.custom_pages = [{


### PR DESCRIPTION
It'd be cool to allow different layouts (besides application.html.erb) for certain view templates:

```ruby
theme.view_templates = [{
  name: "some_template",
  title: "Some template",
  parts: %w(body),
  layout: "special_layout"
}]
```