### PR TITLE
Page delete redirect

### DIFF
--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -7,7 +7,7 @@ module Spina
 
       def index
         add_breadcrumb I18n.t('spina.website.pages'), spina.admin_pages_path
-        
+
         if params[:resource_id]
           @resource = Resource.find(params[:resource_id])
           @page_templates = Spina::Current.theme.new_page_templates(resource: @resource)
@@ -55,7 +55,7 @@ module Spina
           else
             flash[:success] = t('spina.pages.saved')
           end
-          
+
           redirect_to spina.edit_admin_page_url(@page, params: {locale: @locale})
         else
           add_index_breadcrumb
@@ -67,17 +67,17 @@ module Spina
       end
 
       def sort
-        params[:ids].each.with_index do |id, index| 
+        params[:ids].each.with_index do |id, index|
           Page.where(id: id).update_all(position: index + 1)
         end
-        
+
         flash.now[:info] = t("spina.pages.sorting_saved")
         render_flash
       end
-      
+
       def sort_one
         current_position = @page.position
-        
+
         if params[:direction] == "up"
           @bottom_page = @page
           @top_page = @target_page = @page.siblings.where(resource_id: @page.resource_id).sorted.where("position < ?", current_position).last
@@ -85,7 +85,7 @@ module Spina
           @bottom_page = @target_page = @page.siblings.where(resource_id: @page.resource_id).sorted.where("position > ?", current_position).first
           @top_page = @page
         end
-        
+
         if @target_page
           @page.transaction do
             @page.update(position: @target_page.position)
@@ -103,7 +103,7 @@ module Spina
       end
 
       def destroy
-        flash[:info] = t('spina.pages.deleted')    
+        flash[:info] = t('spina.pages.deleted')
         @page.destroy
         redirect_to spina.admin_pages_url
       end
@@ -113,7 +113,7 @@ module Spina
         def set_locale
           @locale = params[:locale] || I18n.default_locale
         end
-  
+
         def add_index_breadcrumb
           if @page.resource
             add_breadcrumb @page.resource.label, spina.admin_pages_path(resource_id: @page.resource_id), class: 'text-gray-400'
@@ -121,11 +121,11 @@ module Spina
             add_breadcrumb t('spina.website.pages'), spina.admin_pages_path, class: 'text-gray-400'
           end
         end
-  
+
         def page_params
           params.require(:page).permit!
         end
-  
+
         def set_page
           @page = Page.find(params[:id])
         end
@@ -133,7 +133,6 @@ module Spina
         def set_tabs
           @tabs = %w[page_content search_engines advanced]
         end
-
     end
   end
 end

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -105,7 +105,8 @@ module Spina
       def destroy
         flash[:info] = t('spina.pages.deleted')
         @page.destroy
-        redirect_to spina.admin_pages_url
+
+        redirect_to spina.admin_pages_url(resource_id: @page.resource_id)
       end
 
       private

--- a/test/integration/spina/admin/pages_test.rb
+++ b/test/integration/spina/admin/pages_test.rb
@@ -35,7 +35,7 @@ module Spina
         get "/admin/pages"
         assert_select 'small', text: "(draft)"
       end
-      
+
       test "publish a page" do
         @page = FactoryBot.create :page, draft: true, title: "A page about dogs"
         get "/admin/pages/#{@page.id}/edit"
@@ -44,26 +44,39 @@ module Spina
         follow_redirect!
         assert_select 'small', {count: 0, text: "(Draft)"}
       end
-      
+
       test "move a page" do
         @homepage = FactoryBot.create :homepage
         @page = FactoryBot.create :page, title: "A page about dogs"
         get "/admin/pages/#{@page.id}/move/new"
         assert_select "button[type='submit']", text: "Move page"
-        
+
         patch "/admin/pages/#{@page.id}/move", params: {page: {parent_id: @homepage.id}}
         @page.reload
         assert_equal @page.parent.id, @homepage.id
       end
-      
+
       test "change a view template" do
         @page = FactoryBot.create :page, title: "A page with a template", view_template: "show"
         get "/admin/pages/#{@page.id}/edit_template"
         assert_select "button[type='submit']", text: "Change view template"
-        
+
         patch "/admin/pages/#{@page.id}", params: {page: {view_template: "demo"}}
         @page.reload
         assert_equal @page.view_template, "demo"
+      end
+
+      test "delete a page" do
+        page = FactoryBot.create(:page, title: "Test")
+        delete "/admin/pages/#{page.id}"
+        assert_redirected_to "/admin/pages"
+      end
+
+      test "delete a page with a resource" do
+        resource = FactoryBot.create(:resource, name: "Test Resource")
+        page = FactoryBot.create(:page, title: "Test Page", resource: resource)
+        delete "/admin/pages/#{page.id}"
+        assert_redirected_to "/admin/pages?resource_id=#{resource.id}"
       end
     end
   end


### PR DESCRIPTION
### Context

When deleting a page the redirect back to `/admin/pages` can break you out of context if the deleted page was within a resource.

### Changes proposed in this pull request

Deleting a page will now redirect as previous but if the page had a resource, the redirect will push the user back to the resource silo.
