### PR TITLE
#1164 - Bugfix for` NoMethodError` when calling `.homepage?` on `NavigationItem` object

### DIFF
--- a/app/presenters/spina/menu_presenter.rb
+++ b/app/presenters/spina/menu_presenter.rb
@@ -91,7 +91,7 @@ module Spina
     end
 
     def parent_of_current?(item)
-      return false if item.homepage?
+      return false if item.page.homepage?
       Spina::Current.page.materialized_path.starts_with? item.materialized_path
     end
   end


### PR DESCRIPTION
Fix NoMethodError resulting from checking the NavigationItem and not… the Page itself.

### Context

When attempting to render a navigation with a given Spina::MenuPresenter, ruby/3.1.3/lib/ruby/gems/3.1.0/gems/activemodel-7.0.3.1/lib/active_model/attribute_methods.rb:458 is called. This results in a NoMethodError when following the recommended [navigation guide](https://spinacms.com/guides/themes-content/adding-navigation-to-your-website).

More details in #1164 


### Changes proposed in this pull request

This PR checks against the `Page` itself to see if it's the homepage; fixing an error. 


### Guidance to review
- [ ] ? Is the `Page` object the only type that would be included in the `NavigationItem` enumerable? 