### PR TITLE
Search in Media Library

### DIFF
--- a/app/components/spina/forms/search_component.html.erb
+++ b/app/components/spina/forms/search_component.html.erb
@@ -1,0 +1,16 @@
+<div class="flex items-center relative">
+  <div class="absolute left-3" style="left: 0.75rem;">
+    <%= helpers.heroicon('search', style: :solid, class: 'text-gray-300 w-5 h-5') %>
+  </div>
+
+  <%= @f.search_field @method, 
+    value: params[@method.to_sym],
+    class: "form-input font-medium block pl-10 pr-2 py-[0.3rem]"
+  %>
+
+  <div class="absolute right-2">
+    <%= link_to request.path do %>
+      <%= helpers.heroicon('x', style: :solid, class: 'text-gray-300 w-5 h-5') %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/spina/forms/search_component.rb
+++ b/app/components/spina/forms/search_component.rb
@@ -1,0 +1,12 @@
+module Spina
+  module Forms
+    class SearchComponent < ApplicationComponent
+      attr_accessor :f, :method
+
+      def initialize(f, method)
+        @f = f
+        @method = method
+      end
+    end
+  end
+end

--- a/app/controllers/spina/admin/attachments_controller.rb
+++ b/app/controllers/spina/admin/attachments_controller.rb
@@ -5,6 +5,10 @@ module Spina
 
       def index
         @attachments = Attachment.sorted.with_attached_file.page(params[:page]).per(25)
+
+        if params[:query].present?
+          @attachments = @attachments.with_filename(params[:query])
+        end
       end
 
       def show

--- a/app/controllers/spina/admin/images_controller.rb
+++ b/app/controllers/spina/admin/images_controller.rb
@@ -7,6 +7,10 @@ module Spina
       def index
         @media_folders = MediaFolder.order(:name).includes(:images)
         @images = Image.sorted.where(media_folder: @media_folder).with_attached_file.page(params[:page]).per(25)
+
+        if params[:query].present?
+          @images = @images.with_filename(params[:query])
+        end
       end
 
       def show

--- a/app/models/spina/attachment.rb
+++ b/app/models/spina/attachment.rb
@@ -5,6 +5,12 @@ module Spina
     attr_accessor :_destroy
 
     scope :sorted, -> { order("created_at DESC") }
+    scope :with_filename, ->(query) do
+      joins(:file_blob).where(
+        "active_storage_blobs.filename ILIKE ?",
+        "%" + Attachment.sanitize_sql_like(query) + "%"
+      )
+    end
 
     def name
       file.filename.to_s

--- a/app/models/spina/image.rb
+++ b/app/models/spina/image.rb
@@ -5,6 +5,12 @@ module Spina
     has_one_attached :file
 
     scope :sorted, -> { order("created_at DESC") }
+    scope :with_filename, ->(query) do
+      joins(:file_blob).where(
+        "active_storage_blobs.filename ILIKE ?",
+        "%" + Image.sanitize_sql_like(query) + "%"
+      )
+    end
 
     def name
       file.try(:filename).to_s

--- a/app/views/spina/admin/attachments/index.html.erb
+++ b/app/views/spina/admin/attachments/index.html.erb
@@ -1,5 +1,11 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
   <% header.actions do %>
+    <%= form_with method: :get, url: spina.admin_attachments_path, data: {turbo_frame: "_top"}, class: 'flex gap-2 pr-4 border-r-2 border-gray-200' do |f| %>
+      <%= render Spina::Forms::SearchComponent.new(f, :query) %>
+
+      <%= f.submit value: 'Search', name: nil, class: 'btn btn-default' %>
+    <% end %>
+
     <%= form_with model: [:admin, Spina::Attachment.new], url: spina.admin_attachments_path, data: {controller: "form loading-button", loading_message: t('spina.media_library.uploading'), action: "turbo:submit-end->loading-button#doneLoading"} do |f| %>
     
       <%= f.file_field :files, multiple: true, id: "new_attachment_file_field", class: 'hidden', data: {action: "loading-button#loading form#requestSubmit"} %>

--- a/app/views/spina/admin/images/index.html.erb
+++ b/app/views/spina/admin/images/index.html.erb
@@ -1,5 +1,11 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
   <% header.actions do %>
+    <%= form_with method: :get, url: spina.admin_images_path, data: {turbo_frame: "_top"}, class: 'flex gap-2 pr-4 border-r-2 border-gray-200' do |f| %>
+      <%= render Spina::Forms::SearchComponent.new(f, :query) %>
+
+      <%= f.submit value: 'Search', name: nil, class: 'btn btn-default' %>
+    <% end %>
+
     <% if @media_folder.blank? %>
       <%= link_to spina.new_admin_media_folder_path, class: "btn btn-default", data: {turbo_frame: "modal"} do %>
         <%= heroicon("folder", style: :solid, class: 'w-4 h-4 mr-1 -ml-1') %>

--- a/test/system/spina/admin/searching_media_library_test.rb
+++ b/test/system/spina/admin/searching_media_library_test.rb
@@ -1,0 +1,20 @@
+require "application_system_test_case"
+
+module Spina
+  class Admin::SearchingMediaLibraryTest < ApplicationSystemTestCase
+    test "searching for a specific file" do
+      spina_png = fixture_file_upload("spina.png", "image/png")
+      Spina::Image.create(file: spina_png)
+
+      other_image = Spina::Image.create(file: spina_png)
+      other_image.file_blob.update(filename: "other.png")
+
+      visit spina.admin_images.path
+      assert_text "spina.png"
+
+      fill_in "query", with: "other"
+      refute_text "spina.png"
+      assert_text "other.png"
+    end
+  end
+end


### PR DESCRIPTION
### Context

We've had a client ask before about whether they can search within the media library to find uploaded items. I've experimented a bit with adding a simple search input in the header there to allow filtering by filename.

Here's a video demo of the UI for this PR: https://www.loom.com/share/52e45ba749404711b59593e0473b8b4a

### Changes proposed in this pull request

In this pull request, I've added a search bar to the tabs within the Media Library at the top right. Typing text and pressing enter or clicking Search filters the list to only those media library items that contain the search text.

### Guidance to review

Using the feature is fairly straightforward:
1. Log in to the Spina admin panel.
2. Browse to the Media Library.
3. Enter a filename in the search box at the top-right and confirm that the list of files is filtered as expected.
4. Click the "X" icon to clear the search and restore the full list.

### Questions

- Does this feature make sense within Spina core? I can see it being helpful for finding existing library files, but those files are not always named clearly for searching.
- Any thoughts on the UI? I'm not sure what the best placement for the searching UI should be. Perhaps right-aligned beneath the action buttons could work well also.

I'm open to any suggestions or ideas 👍 If this is a helpful feature, I'd be open to adding the ability to search the main list of Spina pages as well.