### PR TITLE
Rewrite rules change

### DIFF
--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -115,9 +115,11 @@ module Spina
     end
 
     def rewrite_rule
-      RewriteRule.where(old_path: materialized_path).delete_all
-      RewriteRule.where(new_path: old_path).update(new_path: materialized_path)
-      RewriteRule.where(old_path: old_path).first_or_create.update(new_path: materialized_path) if old_path != materialized_path
+      if old_path != materialized_path
+        RewriteRule.where(old_path: materialized_path).delete_all
+        RewriteRule.where(new_path: old_path).update(new_path: materialized_path)
+        RewriteRule.where(old_path: old_path).first_or_create.update(new_path: materialized_path)
+      end
     end
 
     def localized_materialized_path

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -39,7 +39,7 @@ module Spina
     after_save :touch_navigations
 
     # Create a 301 redirect if materialized_path changed
-    after_update :rewrite_rule
+    after_update :redirect_to_new_path, if: :path_changed?
 
     before_validation :set_materialized_path
     validates :title, presence: true
@@ -114,12 +114,14 @@ module Spina
       navigations.update_all(updated_at: Time.zone.now)
     end
 
-    def rewrite_rule
-      if old_path != materialized_path
-        RewriteRule.where(old_path: materialized_path).delete_all
-        RewriteRule.where(new_path: old_path).update(new_path: materialized_path)
-        RewriteRule.where(old_path: old_path).first_or_create.update(new_path: materialized_path)
-      end
+    def path_changed?
+      old_path != materialized_path
+    end
+
+    def redirect_to_new_path
+      RewriteRule.where(old_path: materialized_path).delete_all
+      RewriteRule.where(new_path: old_path).update(new_path: materialized_path)
+      RewriteRule.where(old_path: old_path).first_or_create.update(new_path: materialized_path)
     end
 
     def localized_materialized_path

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -115,7 +115,7 @@ module Spina
     end
 
     def rewrite_rule
-      RewriteRule.where(new_path: old_path, old_path: materialized_path).delete_all
+      RewriteRule.where(old_path: materialized_path).delete_all
       RewriteRule.where(new_path: old_path).update(new_path: materialized_path)
       RewriteRule.where(old_path: old_path).first_or_create.update(new_path: materialized_path) if old_path != materialized_path
     end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -115,6 +115,8 @@ module Spina
     end
 
     def rewrite_rule
+      RewriteRule.where(new_path: old_path, old_path: materialized_path).delete_all
+      RewriteRule.where(new_path: old_path).update(new_path: materialized_path)
       RewriteRule.where(old_path: old_path).first_or_create.update(new_path: materialized_path) if old_path != materialized_path
     end
 


### PR DESCRIPTION
Change the rewrite rules method so that the new_path is always the currently active one. This way, there will always be only one redirect instead of multiple ones in case a page handle gets renamed more than once.

Also, this gets rid of the following problem that exists until now:

1. You start with page A that has path a, and page B that has path b.
2. You set a new path c for page A, that triggers a rewrite rule from a to c.
3. You set a new path d for page A, that triggers a rewrite rule from c to d.
4. You set a new path c (the same one you set for page A in step 2) for page B, that triggers a rewrite rule from b to c.
5. You visit path a where page A has been and will get redirected to path c, where page B is now – **that's not what you want.**
You visit path b where page B has been and will get redirected to path c where page B is now – that's what you want.
You visit path c where page A has been but page B is now, so you will not get redirected – this is probably also what you want.

With this PR, you will now have the following:

1. You start with page A that has path a, and page B that has path b.
2. You set a new path c for page A, that triggers a rewrite rule from a to c.
3. You set a new path d for page A, that triggers a rewrite rule from c to d and also change the rule set in step 2 – this rewrite rule will now be from a to d.
4. You set a new path c (the same one you set for page A in step 2) for page B, that triggers a rewrite rule from b to c and will also remove the rewrite rule from c to d – so you have 2 rewrite rules now, from a to d and from b to c.
5. You visit path a where page A has been and will get redirected to path d, where page A is now – **that's what you want.**
You visit path b where page B has been and will get redirected to path c where page B is now – that's also what you want.
You visit path c where page A has been but page B is now, so you will not get redirected – this is probably also what you want.