### PR TITLE
Remove hidden class from infinite scroll button

### DIFF
--- a/app/views/spina/admin/attachments/index.html.erb
+++ b/app/views/spina/admin/attachments/index.html.erb
@@ -42,7 +42,7 @@
         
         <% if @attachments.next_page %>
           <%= turbo_frame_tag "attachments-#{@attachments.next_page}", data: {action: "turbo:frame-load->infinite-scroll#load"} do %>
-            <%= link_to t('spina.ui.load_more'), path_to_next_page(@attachments), class: 'hidden', data: {infinite_scroll_target: "button"} %>
+            <%= link_to t('spina.ui.load_more'), path_to_next_page(@attachments), class: "btn btn-default", data: {infinite_scroll_target: "button"} %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Context

Hidden elements do not provide rectangle coordinates that infinite scroll controller is relying on. This causes all pagination to be loaded immediately.

### Changes proposed in this pull request

Update button class to be non-hidden classes. This is in line with what is used across the site.
