### PR TITLE
change field insertion method for repeater

### DIFF
--- a/app/assets/javascripts/spina/controllers/repeater_controller.js
+++ b/app/assets/javascripts/spina/controllers/repeater_controller.js
@@ -40,9 +40,11 @@ export default class extends Controller {
 
     // Insert button
     this.listTarget.insertAdjacentHTML('beforeend', this.buttonHTML(time))
-
     // Insert fields
-    this.contentTarget.insertAdjacentHTML('beforeend', html)
+    const parser = new DOMParser();
+    const docFields = parser.parseFromString(html, 'text/html');
+    this.contentTarget.appendChild(docFields.body.firstChild);
+
   }
 
   removeFields(event) {


### PR DESCRIPTION
### Context
Search input does not work while the repeater part is not saved #1253 

### Changes proposed in this pull request
Replace `insertAdjacentHTML` for the fields with `appendChild` since this approach does allow nested `<form>` elements

### Guidance to review
The tests passed though I could not make the UI tests to work. Did not see any Repeater related tests though. Let me know if I need to add something.