### PR TITLE
Add data-trix-button-group to trix toolbar

### DIFF
--- a/app/components/spina/forms/trix_toolbar_component.html.erb
+++ b/app/components/spina/forms/trix_toolbar_component.html.erb
@@ -1,6 +1,6 @@
 <div class="relative sticky z-10 top-0 pt-4 bg-white trix-toolbar" id="<%= @trix_id %>">
   <div class="flex items-center flex-wrap" data-controller="reveal">
-    <div class="flex items-center bg-gray-200 rounded overflow-hidden mb-3 mr-3">
+    <div class="flex items-center bg-gray-200 rounded overflow-hidden mb-3 mr-3" data-trix-button-group="text-tools">
       <button type="button" class="hover:bg-gray-300 text-gray-700 w-9 h-9 flex items-center justify-center" data-trix-attribute="bold" data-trix-key="b" title="${Trix.config.lang.bold}" tabindex="-1">
         <svg class="w-4 h-4" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M333.49 238a122 122 0 0 0 27-65.21C367.87 96.49 308 32 233.42 32H34a16 16 0 0 0-16 16v48a16 16 0 0 0 16 16h31.87v288H34a16 16 0 0 0-16 16v48a16 16 0 0 0 16 16h209.32c70.8 0 134.14-51.75 141-122.4 4.74-48.45-16.39-92.06-50.83-119.6zM145.66 112h87.76a48 48 0 0 1 0 96h-87.76zm87.76 288h-87.76V288h87.76a56 56 0 0 1 0 112z"/></svg>
       </button>
@@ -27,7 +27,7 @@
       </button>
     </div>
   
-    <div class="flex items-center bg-gray-200 rounded overflow-hidden mr-3 mb-3">
+    <div class="flex items-center bg-gray-200 rounded overflow-hidden mr-3 mb-3" data-trix-button-group="file-tools">
       
       <%= link_to helpers.spina.admin_media_picker_path(target: "insert_#{@trix_id}"), class: "hover:bg-gray-300 text-gray-700 w-9 h-9 flex items-center justify-center", data: {turbo_frame: "modal"} do %>
         <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
### Context
Adding data attributes to button groups in Trix to be closer to default Trix.
See: https://github.com/basecamp/trix/blob/main/src/trix/config/toolbar.js

This is helpful when adding custom buttons to the toolbar that origin from other Rails+Trix/ActionText projects.

### Changes proposed in this pull request
To keep backwards compatibility I've only added two button group data attributes for `text-tools` and `file-tools`. `data-trix-button-group="block-tools"` was already there, but arguably on the wrong button group. I didn't want to introduce breaking changes though. I think the button group at the very right (quote, code...) should be `block-tools` as in default Trix. But what should the h1, h2, h3, h4 be called then? Trix has h1 mixed with quote, code... as `block-tools`.

### Guidance to review
None