### PR TITLE
Allow ancestry to be set in custom pages

### DIFF
--- a/app/models/spina/account.rb
+++ b/app/models/spina/account.rb
@@ -72,9 +72,16 @@ module Spina
 
     def find_or_create_custom_pages(theme)
       theme.custom_pages.each do |page|
+        ancestry = nil
+
+        if page[:parent].present?
+          parent_page = Page.find_by(name: page[:parent])
+          ancestry = [parent_page&.ancestry, parent_page&.id].compact.join("/")
+        end
+        
         Page.where(name: page[:name])
           .first_or_create(title: page[:title])
-          .update(view_template: page[:view_template], deletable: page[:deletable])
+          .update(view_template: page[:view_template], deletable: page[:deletable], ancestry: ancestry)
       end
     end
 

--- a/docs/v2/themes/5_custom_pages.md
+++ b/docs/v2/themes/5_custom_pages.md
@@ -1,3 +1,31 @@
 # Custom pages
 
-You can define custom pages for your theme that will be generated when bootstrapping your website. You can define whether or not they're deletable. By default Spina creates a custom page named Homepage which is not deletable.
+You can define custom pages for your theme that will be generated when bootstrapping your website.
+You can define whether or not they're deletable. By default Spina creates a custom page named Homepage which is not deletable.
+You can define nested pages by passing the name of a custom page as the parent.
+
+You define custom pages in your theme's config file:
+
+```
+::Spina::Theme.register do |theme|
+  # ...
+
+  theme.custom_pages = [
+    {
+      name: "homepage",
+      title: "Homepage",
+      deletable: false,
+      view_template: "homepage"
+    },
+    {
+      name: "articles",
+      title: "Articles",
+      deletable: false,
+      view_template: "articles",
+      parent: "homepage"
+    }
+  ]
+
+  # ...
+end
+```

--- a/test/models/spina/account_test.rb
+++ b/test/models/spina/account_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+module Spina
+  class AccountTest < ActiveSupport::TestCase    
+    def setup
+      @account = FactoryBot.create :account
+      @theme = Spina::Theme.find_by_name(@account.theme)
+    end
+
+    test "after_save callback to bootstrap_navigations creates navigations" do
+      @theme.navigations << {name: "navigation", label: "Navigation"}
+      @account.save
+      navigation = Spina::Navigation.find_by(name: "navigation")
+      
+      assert navigation
+    end
+
+    test "after_save callback to bootstrap_pages creates custom pages" do
+      @theme.custom_pages << {name: "page", title: "Page", deletable: true, view_template: "page_template"}
+      @account.save
+      page = Spina::Page.find_by(name: "page")
+      
+      assert page
+    end
+
+    test "after_save callback to bootstrap_pages creates nested pages" do
+      parent_page = FactoryBot.create :parent_page
+      @theme.custom_pages << {name: "child", title: "Child", deletable: true, view_template: "child_page", parent: parent_page.name}
+      @account.save
+      child_page = Spina::Page.find_by(name: "child")
+
+      assert_equal child_page.parent, parent_page
+    end
+
+    test "after_save callback to bootstrap_pages deactivates pages with unused templates" do
+      @theme.custom_pages << {name: "page", title: "Page", deletable: true, active: true, view_template: "invalid_template"}
+      @account.save
+      page = Spina::Page.find_by(name: "page")
+
+      assert_not page.active
+    end
+
+    test "after_save callback to bootstrap_pages activates pages with used templates" do
+      @theme.view_templates << {name: "valid_template", title: "Template"}
+      @theme.custom_pages << {name: "page", title: "Page", deletable: true, active: false, view_template: "valid_template"}
+      @account.save
+      page = Spina::Page.find_by(name: "page")
+
+      assert page.active
+    end
+
+    test "after_save callback to bootstrap_resources creates resources" do
+      @theme.resources << {name: "resource", label: "Resource", view_template: "resource_template", slug: "resource"}
+      @account.save
+      resource = Spina::Resource.find_by(name: "resource")
+      
+      assert resource
+    end
+  end
+end


### PR DESCRIPTION
### Context
Currently you are unable to nest custom pages from a theme.

### Changes proposed in this pull request
Add the ability to add  `parent` key to the custom_pages.

```ruby
theme.custom_pages = [
  {name: "homepage", title: "Homepage", view_template: "homepage"},
  {name: "nested_page", title: "Nested Page", view_template: "show", parent: "homepage"},
  {name: "double_nested_page", title: "Double Nested Page", view_template: "show", parent: "nested_page"},
]
```

### Guidance to review
If a parent is requested before a page is generated, it will not be able to be linked, however it will not blow up.