### PR TITLE
Switch libvips to libvips-dev dependency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Install libvips
-      run: sudo apt-get install -y libvips
+      run: sudo apt-get install -y libvips-dev
     
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
### Context

Attempt at fixing the following error in CI:
```
Error:
Spina::Admin::SearchingMediaLibraryTest#test_searching_for_a_specific_file:
LoadError: Could not open library 'vips.so.42': vips.so.42: cannot open shared object file: No such file or directory.
Could not open library 'libvips.so.42': libvips.so.42: cannot open shared object file: No such file or directory
```

See similar issue: https://github.com/loomio/loomio/issues/9492

### Changes proposed in this pull request

Tweak dependency in test setup
