### PR TITLE
Paste and upload image into Trix editor from Clipboard

### DIFF
--- a/app/assets/javascripts/spina/controllers/auto_file_upload_controller.js
+++ b/app/assets/javascripts/spina/controllers/auto_file_upload_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  start(event) {
+    const file = event.detail.file
+    if (!file) return
+
+    const trixId = event.detail.trixId
+    this.trixTargetId = trixId
+
+    // DataTransfer() avoids the "TypeError: Failed to set the 'files' property on 'HTMLInputElement': Failed to convert
+    // value to 'FileList'." error which occurs if you try to directly assign: `this.fileField.files = [file]`
+    // https://stackoverflow.com/questions/52078853/is-it-possible-to-update-filelist
+    const fileList = new DataTransfer()
+    fileList.items.add(file)
+    this.fileField.files = fileList.files
+
+    const changeEvent = new Event("input"); // This triggers the upload
+    this.fileField.dispatchEvent(changeEvent);
+  }
+
+  get fileField() {
+    return this.element.querySelector('form input.image-upload-file-field')
+  }
+
+  get form() {
+    return this.element.querySelector('form')
+  }
+
+  get trixTargetId() {
+    return this.element.querySelector('form > #trix_target_id').value
+  }
+
+  set trixTargetId(value) {
+    this.element.querySelector('form > #trix_target_id').value = value
+  }
+
+  #imageData(imageMeta) {
+    return {
+      filename: imageMeta.dataset.filename,
+      signedBlobId: imageMeta.dataset.signedBlobId,
+      imageId: imageMeta.dataset.imageId,
+      embeddedUrl: imageMeta.dataset.embeddedUrl,
+      thumbnail: imageMeta.dataset.thumbnail
+    }
+  }
+
+}

--- a/app/assets/javascripts/spina/controllers/editor_insert_images_controller.js
+++ b/app/assets/javascripts/spina/controllers/editor_insert_images_controller.js
@@ -9,7 +9,6 @@ export default class extends Controller {
 
   insertImages() {
     const imagesMetadata = this.element.querySelectorAll('div.trix-insert-image')
-    console.log('Inserting images', imagesMetadata)
     imagesMetadata.forEach(tag => {
       const imageData = this.#imageData(tag)
       let insertImageEvent = new CustomEvent("media-picker:done", {detail: imageData})

--- a/app/assets/javascripts/spina/controllers/editor_insert_images_controller.js
+++ b/app/assets/javascripts/spina/controllers/editor_insert_images_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  connect() {
+    // Gets triggered when refreshed by the ImagesController, and will process any images here
+    this.insertImages()
+  }
+
+  insertImages() {
+    const imagesMetadata = this.element.querySelectorAll('div.trix-insert-image')
+    console.log('Inserting images', imagesMetadata)
+    imagesMetadata.forEach(tag => {
+      const imageData = this.#imageData(tag)
+      let insertImageEvent = new CustomEvent("media-picker:done", {detail: imageData})
+      const targetEditor = document.getElementById(this.trixTargetId)
+      this.trixTarget.dispatchEvent(insertImageEvent)
+    })
+  }
+
+  get trixTarget() {
+    return document.getElementById(this.trixTargetId)
+  }
+
+  get trixTargetId() {
+    return this.element.dataset.trixTargetId
+  }
+
+  #imageData(imageMeta) {
+    return {
+      filename: imageMeta.dataset.filename,
+      signedBlobId: imageMeta.dataset.signedBlobId,
+      imageId: imageMeta.dataset.imageId,
+      embeddedUrl: imageMeta.dataset.embeddedUrl,
+      thumbnail: imageMeta.dataset.thumbnail
+    }
+  }
+
+}

--- a/app/assets/javascripts/spina/controllers/trix_controller.js
+++ b/app/assets/javascripts/spina/controllers/trix_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
       }
     }.bind(this))
   }
-  
+
   insertEmbeddable(html) {
     let embeddable = new Trix.Attachment({
       content: html, 
@@ -38,7 +38,15 @@ export default class extends Controller {
     </span>`, contentType: "Spina::Image"})
     this.editor.insertAttachment(attachment)
   }
-  
+
+  fileAccept(event) {
+    const file = event.file
+    if(file) {
+      const startUploadEvent = new CustomEvent("auto-file-upload:start", { detail: { file, trixId: this.trixId }})
+      window.dispatchEvent(startUploadEvent)
+    }
+  }
+
   setAltText(event) {
     let alt = event.currentTarget.value
     let altLabel = alt
@@ -80,6 +88,10 @@ export default class extends Controller {
   
   get trixAttachment() {
     return this.getTrixAttachment(this.mutableImageAttachment.dataset.trixId)
+  }
+
+  get trixId() {
+    return this.element.id
   }
   
   get mutableImageAttachment() {

--- a/app/components/spina/forms/auto_file_upload_component.html.erb
+++ b/app/components/spina/forms/auto_file_upload_component.html.erb
@@ -1,0 +1,6 @@
+<div data-controller="auto-file-upload" data-action="auto-file-upload:start@window->auto-file-upload#start">
+  <%= render Spina::Forms::FileUploadComponent.new(origin: 'auto-file-upload', css_classes: 'hidden', turbo_frame: turbo_frame_id) %>
+  <turbo-frame id="auto-file-upload-images" data-trix-insert-target="">
+    <%= render Spina::Forms::EditorInsertImagesMetaComponent.new %>
+  </turbo-frame>
+</div>

--- a/app/components/spina/forms/auto_file_upload_component.rb
+++ b/app/components/spina/forms/auto_file_upload_component.rb
@@ -1,0 +1,15 @@
+module Spina
+  module Forms
+
+    # Meant to be a hidden component for facilitating quick file uploads from drag and drop or paste action within Trix
+    class AutoFileUploadComponent < ApplicationComponent
+      attr_reader :turbo_frame_id
+
+      def initialize
+        @turbo_frame_id = "auto-file-upload-images"
+      end
+
+    end
+
+  end
+end

--- a/app/components/spina/forms/editor_insert_images_meta_component.html.erb
+++ b/app/components/spina/forms/editor_insert_images_meta_component.html.erb
@@ -1,0 +1,12 @@
+<div id="auto-uploaded-images" data-controller="editor-insert-images" data-trix-target-id="<%= trix_target_id %>">
+  <% @images.each do |image| %>
+    <div
+      class="hidden trix-insert-image"
+      data-image-id="<%= image.id %>"
+      data-signed-blob-id="<%= image.file.blob&.signed_id %>"
+      data-filename="<%= image.file.filename %>"
+      data-thumbnail="<%= helpers.thumbnail_url(image) %>"
+      data-embedded-url="<%= helpers.embedded_image_url(image) %>"
+    ></div>
+  <% end %>
+</div>

--- a/app/components/spina/forms/editor_insert_images_meta_component.rb
+++ b/app/components/spina/forms/editor_insert_images_meta_component.rb
@@ -1,0 +1,12 @@
+module Spina
+  module Forms
+    class EditorInsertImagesMetaComponent < ApplicationComponent
+      attr_reader :images, :trix_target_id
+
+      def initialize(trix_target_id: nil, images:[])
+        @trix_target_id = trix_target_id
+        @images = images
+      end
+    end
+  end
+end

--- a/app/components/spina/forms/file_upload_component.html.erb
+++ b/app/components/spina/forms/file_upload_component.html.erb
@@ -1,0 +1,14 @@
+<div data-controller="file-upload-component" class=<%= @css_classes %>>
+  <%= form_with model: [:admin, Spina::Image.new], url: helpers.spina.admin_images_path, data: {controller: "form loading-button", loading_message: t('spina.media_library.uploading'), action: "turbo:submit-end->loading-button#doneLoading", origin: origin, turbo_frame: turbo_frame} do |f| %>
+    <%= hidden_field_tag :origin, origin %>
+    <%= hidden_field_tag :trix_target_id, value: @trix_target_id %>
+    <%= f.hidden_field :media_folder_id, value: media_folder&.id %>
+
+    <%= f.file_field :files, multiple: true, accept: "image/*", id: file_field_id, class: 'image-upload-file-field hidden', data: {action: "loading-button#loading form#requestSubmit"} %>
+
+    <%= button_tag(type: "button", class: "font-medium w-full text-gray-600 text-sm hover:bg-gray-200 px-3 py-2 cursor-pointer rounded-lg flex items-center w-full", data: { controller:"delegate-click", action: "delegate-click#click", 'loading-button-target': "button", 'delegate-click-target': "##{file_field_id}" }) do %>
+      <%= helpers.heroicon("upload", style: :solid, class: "w-5 h-5 text-spina mr-2") %>
+      <%=t 'spina.media_library.upload_from_device' %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/spina/forms/file_upload_component.rb
+++ b/app/components/spina/forms/file_upload_component.rb
@@ -1,0 +1,19 @@
+module Spina
+  module Forms
+    class FileUploadComponent < ApplicationComponent
+      attr_reader :css_classes, :id, :origin, :file_field_id, :media_folder, :trix_id, :turbo_frame
+
+      def initialize(origin:, css_classes: '', id: nil, trix_target_id: nil, media_folder: nil, turbo_frame: nil)
+        @origin = origin
+        @css_classes = css_classes
+        @id = id || SecureRandom.uuid
+        @media_folder = media_folder
+        @trix_target_id = trix_target_id # If inserting an image into Trix, specifies which one receives it
+        @turbo_frame = turbo_frame
+
+        @file_field_id = "image_upload_file_field_#{@id}"
+      end
+
+    end
+  end
+end

--- a/app/components/spina/media_picker/modal_component.html.erb
+++ b/app/components/spina/media_picker/modal_component.html.erb
@@ -58,17 +58,7 @@
               <% end %>
             <% end %>
             
-            <%= form_with model: [:admin, Spina::Image.new], url: helpers.spina.admin_images_path, data: {controller: "form loading-button", loading_message: t('spina.media_library.uploading'), action: "turbo:submit-end->loading-button#doneLoading", turbo_frame: "media_picker"} do |f| %>
-              <%= hidden_field_tag :modal, true %>
-              <%= f.hidden_field :media_folder_id, value: @media_folder&.id %>
-              
-              <%= f.file_field :files, multiple: true, accept: "image/*", id: "new_image_file_field", class: 'hidden', data: {action: "loading-button#loading form#requestSubmit"} %>
-              
-              <button type="button" class="font-medium w-full text-gray-600 text-sm hover:bg-gray-200 px-3 py-2 cursor-pointer rounded-lg flex items-center w-full" data-controller="delegate-click" data-action="delegate-click#click" data-loading-button-target="button" data-delegate-click-target="#new_image_file_field">
-                <%= helpers.heroicon("upload", style: :solid, class: "w-5 h-5 text-spina mr-2") %>
-                <%=t 'spina.media_library.upload_from_device' %>
-              </button>
-            <% end %>
+            <%= render Spina::Forms::FileUploadComponent.new(origin: 'media-picker', media_folder: @media_folder, turbo_frame: 'media_picker') %>
           </div>
           
           <button type="button" class="btn btn-primary w-full mt-3" data-action="media-picker-modal#confirm modal#close">

--- a/app/controllers/spina/admin/images_controller.rb
+++ b/app/controllers/spina/admin/images_controller.rb
@@ -35,8 +35,15 @@ module Spina
           image
         end.compact
 
-        if params[:modal]
+        if params[:origin] == 'media-picker'
           redirect_to spina.admin_media_picker_path(media_folder_id: image_params[:media_folder_id])
+        elsif params[:origin] == 'auto-file-upload'
+          render turbo_stream: turbo_stream.update(
+            'auto-file-upload-images',
+            Spina::Forms::EditorInsertImagesMetaComponent
+              .new(images: @images, trix_target_id: params[:trix_target_id])
+              .render_in(view_context)
+          )
         else
           render turbo_stream: turbo_stream.prepend("images", partial: "image", collection: @images)
         end

--- a/app/views/layouts/spina/admin/admin.html.erb
+++ b/app/views/layouts/spina/admin/admin.html.erb
@@ -13,6 +13,8 @@
   
   <!-- Make sure all modals are rendered in this frame -->
   <%= turbo_frame_tag "modal" %>
+
+  <%= render Spina::Forms::AutoFileUploadComponent.new %>
 <% end %>
 
 <%= render template: 'layouts/spina/admin/application' %>

--- a/app/views/spina/admin/parts/texts/_form.html.erb
+++ b/app/views/spina/admin/parts/texts/_form.html.erb
@@ -11,4 +11,3 @@
     </div>
   </div>
 </div>
-<%#= render Spina::Forms::FileUploadComponent.new(id: f.object.object_id, css_classes: 'hidden', turbo_frame: 'page_content') %>

--- a/app/views/spina/admin/parts/texts/_form.html.erb
+++ b/app/views/spina/admin/parts/texts/_form.html.erb
@@ -4,10 +4,11 @@
   <div class="mt-1 relative">
     <%= f.hidden_field :content, id: "#{f.object.object_id}_input" %>
 
-    <div class="relative form-textarea p-4 pt-0 shadow-sm max-w-5xl" data-controller="trix" id="<%= "insert_#{f.object.object_id}_trix-toolbar" %>" data-action="media-picker:done->trix#insertAttachment">      
+    <div class="relative form-textarea p-4 pt-0 shadow-sm max-w-5xl" data-controller="trix" id="<%= "insert_#{f.object.object_id}_trix-toolbar" %>" data-action="media-picker:done->trix#insertAttachment trix-file-accept->trix#fileAccept">
       <%= render Spina::Forms::TrixToolbarComponent.new("#{f.object.object_id}_trix-toolbar") %>
       
       <trix-editor class="prose prose-sm focus:outline-none max-w-3xl xl:border-r border-dashed border-gray-200 pr-3" toolbar="<%= f.object.object_id %>_trix-toolbar" input="<%= f.object.object_id %>_input" data-trix-target="editor" data-action="trix-file-accept->trix#preventDefault"></trix-editor>
     </div>
   </div>
 </div>
+<%#= render Spina::Forms::FileUploadComponent.new(id: f.object.object_id, css_classes: 'hidden', turbo_frame: 'page_content') %>


### PR DESCRIPTION
### Context

As an author using the Trix rich text editor, I would like to insert images into my page content by copy/paste or drag-and-drop directly into the editor.

### Changes proposed in this pull request

Reads the Trix file-accept event to read the details of any pasted file and:
1. Automatically uploads the file data into the media picker
2. Inserts the newly added file into the Trix editor

### Guidance to review

Give it a spin!

![spina-copy-paste-image-demo](https://github.com/SpinaCMS/Spina/assets/1912237/360b0548-e2c1-4e01-9f35-f08b0af52468)
