### PR TITLE
Use default theme by default

### DIFF
--- a/lib/generators/spina/install_generator.rb
+++ b/lib/generators/spina/install_generator.rb
@@ -46,10 +46,11 @@ module Spina
       account = ::Spina::Account.first
       return if account.theme.present? && (silent_install? || !no?("Theme '#{account.theme}' is set. Skip? [Yn]"))
 
+      default_theme = account.theme || themes.first
       theme = if talkative_install?
-        ask("What theme do you want to use?", limited_to: themes)
+        ask("What theme do you want to use?", limited_to: themes, default: default_theme)
       else
-        account.theme || themes.first
+        default_theme
       end
 
       account.update(theme: theme)


### PR DESCRIPTION
### Context
The generator provides defaults for all options except for the theme.

### Changes proposed in this pull request
Provide a default theme value so that installation can proceed simply by pressing Enter.

### Guidance to review
run `rails g spina:install` and observe that the default theme is used when just typing Enter.