### PR TITLE
Use left_outer_joins for NavigationItem scopes - Fixes #1294

### DIFF
--- a/app/models/spina/navigation_item.rb
+++ b/app/models/spina/navigation_item.rb
@@ -12,9 +12,9 @@ module Spina
 
     scope :regular_pages, -> { joins(:page).where(spina_pages: {resource_id: nil}) }
     scope :sorted, -> { order("spina_navigation_items.position") }
-    scope :live, -> { joins(:page).where(spina_pages: {draft: false, active: true}) }
-    scope :in_menu, -> { joins(:page).where(spina_pages: {show_in_menu: true}) }
-    scope :active, -> { joins(:page).where(spina_pages: {active: true}) }
+    scope :live, -> { left_outer_joins(:page).where("spina_pages.draft = ? AND spina_pages.active = ? OR spina_pages.id IS NULL", false, true) }
+    scope :in_menu, -> { left_outer_joins(:page).where("spina_pages.show_in_menu = ? OR spina_pages.id IS NULL", true) }
+    scope :active, -> { left_outer_joins(:page).where("spina_pages.active = ? OR spina_pages.id IS NULL", true) }
 
     validates :page, uniqueness: {scope: :navigation}, presence: true, if: :page_kind?
     validates :url, presence: true, if: :url_kind?

--- a/app/presenters/spina/menu_presenter.rb
+++ b/app/presenters/spina/menu_presenter.rb
@@ -65,7 +65,7 @@ module Spina
     end
 
     def scoped_collection(collection)
-      scoped = collection.regular_pages.active.in_menu.sorted
+      scoped = collection.active.in_menu.sorted
       include_drafts ? scoped : scoped.live
     end
 


### PR DESCRIPTION
Because of the addition of custom URLs in NavigationItems, scopes on NavigationItem should use `left_outer_joins(:page)` instead of `joins(:page)`.

Also, it doesn't make sense to use the `regular_pages` scope in the MenuPresenter. 