### PR TITLE
Layout parts split in different sections

### DIFF
--- a/app/controllers/spina/admin/layout_controller.rb
+++ b/app/controllers/spina/admin/layout_controller.rb
@@ -3,6 +3,7 @@ module Spina::Admin
     before_action :set_account
     before_action :set_locale
     before_action :set_breadcrumb
+    before_action :get_layout_parts
 
     admin_section :content
 
@@ -23,6 +24,11 @@ module Spina::Admin
     # Permit all attributes when editing your layout
     def layout_params
       params.require(:account).permit!
+    end
+    
+    def get_layout_parts
+      @layout_parts = Spina::Current.theme.layout_parts
+      @layout_parts = {parts: @layout_parts} if @layout_parts.is_a?(Array)
     end
 
     def set_breadcrumb

--- a/app/views/spina/admin/layout/edit.html.erb
+++ b/app/views/spina/admin/layout/edit.html.erb
@@ -3,11 +3,9 @@
     <% header.with_actions do %>
       <%= render Spina::UserInterface::TranslationsComponent.new(@account, label: @locale.upcase) %>
     
-      <% if Spina::Current.theme.layout_parts.any? %>
-        <%= button_tag type: :submit, form: dom_id(@account), class: 'btn btn-primary', data: {controller: "button hotkeys", hotkeys: "command+s, ctrl+s", hotkeys_target: "button", action: "button#loading", loading_message: t('spina.ui.saving')} do %>
-          <%= heroicon('check', style: :mini, class: 'w-5 h-5 -ml-1 mr-1') %>
-          <%=t 'spina.layout.save' %>
-        <% end %>
+      <%= button_tag type: :submit, form: dom_id(@account), class: 'btn btn-primary', data: {controller: "button hotkeys", hotkeys: "command+s, ctrl+s", hotkeys_target: "button", action: "button#loading", loading_message: t('spina.ui.saving')} do %>
+        <%= heroicon('check', style: :mini, class: 'w-5 h-5 -ml-1 mr-1') %>
+        <%=t 'spina.layout.save' %>
       <% end %>
     <% end %>
     

--- a/app/views/spina/admin/layout/edit.html.erb
+++ b/app/views/spina/admin/layout/edit.html.erb
@@ -1,36 +1,47 @@
-<%= render Spina::UserInterface::HeaderComponent.new do |header| %>
-  <% header.with_actions do %>
-    <%= render Spina::UserInterface::TranslationsComponent.new(@account, label: @locale.upcase) %>
-  
-    <% if Spina::Current.theme.layout_parts.any? %>
-      <%= button_tag type: :submit, form: dom_id(@account), class: 'btn btn-primary', data: {controller: "button hotkeys", hotkeys: "command+s, ctrl+s", hotkeys_target: "button", action: "button#loading", loading_message: t('spina.ui.saving')} do %>
-        <%= heroicon('check', style: :mini, class: 'w-5 h-5 -ml-1 mr-1') %>
-        <%=t 'spina.layout.save' %>
+<div data-controller="tabs" data-tabs-active="cursor-default text-gray-900 bg-spina-dark bg-opacity-10" data-tabs-inactive="cursor-pointer bg-transparent text-gray-400 border-transparent">
+  <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
+    <% header.with_actions do %>
+      <%= render Spina::UserInterface::TranslationsComponent.new(@account, label: @locale.upcase) %>
+    
+      <% if Spina::Current.theme.layout_parts.any? %>
+        <%= button_tag type: :submit, form: dom_id(@account), class: 'btn btn-primary', data: {controller: "button hotkeys", hotkeys: "command+s, ctrl+s", hotkeys_target: "button", action: "button#loading", loading_message: t('spina.ui.saving')} do %>
+          <%= heroicon('check', style: :mini, class: 'w-5 h-5 -ml-1 mr-1') %>
+          <%=t 'spina.layout.save' %>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
-<% end %>
-  
-<%= form_with model: @account, url: spina.admin_layout_path, id: dom_id(@account) do |f| %>
-  <%= hidden_field_tag :locale, @locale %>
-  
-  <div class="py-4 p-8">
-    <% if Spina::Current.theme.layout_parts.any? %>
-      
-      <div class="max-w-5xl">
-        <%= f.fields_for "#{@locale}_content".to_sym, build_parts(f.object, Spina::Current.theme.layout_parts) do |ff| %>
-          <%= ff.hidden_field :type, value: ff.object.class %>
-          <%= ff.hidden_field :name %>
-          <%= ff.hidden_field :title %>
-  
-          <%= render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.to_s)}/form", f: ff %>
-        <% end %>
-      </div>
-    <% else %>
-      <div class="text-gray-500 italic">
-        <%=t 'spina.layout.no_layout_parts' %>
-      </div>
+    
+    <% header.with_navigation do %>
+      <nav class="-mb-3 mt-4" <%= 'hidden' unless @layout_parts.keys.many? %>>
+        <ul class="inline-flex w-auto rounded-md bg-white">
+          <% @layout_parts.keys.each do |key| %>
+            <%= render Spina::Pages::TabButtonComponent.new(tab_name: key) do %>
+              <%=t "spina.layout.sections.#{key}" %>
+            <% end %>
+          <% end %>
+        </ul>
+      </nav>
     <% end %>
-  </div>
-
-<% end %>
+  <% end %>
+    
+  <%= form_with model: @account, url: spina.admin_layout_path, id: dom_id(@account) do |f| %>
+    <%= hidden_field_tag :locale, @locale %>
+    
+    <div class="py-4 p-8">
+      <% @layout_parts.keys.each.with_index do |key, index| %>
+        <div data-tabs-target="pane" id="<%= key %>">
+          <div class="max-w-5xl">
+            <%= f.fields_for "#{@locale}_content".to_sym, build_parts(f.object, @layout_parts[key]) do |ff| %>
+              <%= ff.hidden_field :type, value: ff.object.class %>
+              <%= ff.hidden_field :name %>
+              <%= ff.hidden_field :title %>
+          
+              <%= render "spina/admin/parts/#{parts_partial_namespace(ff.object.class.to_s)}/form", f: ff %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  
+  <% end %>
+</div>

--- a/app/views/spina/admin/shared/_navigation.html.erb
+++ b/app/views/spina/admin/shared/_navigation.html.erb
@@ -17,8 +17,10 @@
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.pages'), spina.admin_pages_path, active: controller_name.in?(%w(pages resources)) %>
           
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.navigations.navigations'), spina.admin_navigations_path, active: controller_name == "navigations" %>
-
-          <%= render Spina::MainNavigation::LinkComponent.new t('spina.layout.layout'), spina.edit_admin_layout_path, active: controller_name == "layout" %>
+          
+          <% if Spina::Current.theme.layout_parts.present? %>
+            <%= render Spina::MainNavigation::LinkComponent.new t('spina.layout.layout'), spina.edit_admin_layout_path, active: controller_name == "layout" %>
+          <% end %>
           
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.media_library'), spina.admin_images_path, active: controller_name.in?(%w(images media_folders attachments)) %>
           


### PR DESCRIPTION
Add support for different sections for layout parts like so:
<img width="762" alt="CleanShot 2023-09-20 at 10 54 27@2x" src="https://github.com/SpinaCMS/Spina/assets/423116/258a177e-28a9-4fb8-b4e7-43f860c4cfc3">

Instead of assigning an array to `theme.layout_parts`, it's also possible to assign a hash:
```ruby
theme.layout_parts = {
  brand: %w[logo brand_color],
  google_reviews: %w[google_reviews google_rating],
  docs: %w[terms_and_conditions privacy]
}
```

My proposal is to use I18n to add labels for different sections under the `spina.layout.sections` key.