### PR TITLE
Update Post-install Message - v2.16 has a migration

### DIFF
--- a/spina.gemspec
+++ b/spina.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |gem|
   gem.description = "CMS"
   gem.license = "MIT"
   gem.post_install_message = %q{
-    Spina v2.14 includes a new migration, don't forget to run spina:install:migrations.
+    Spina v2.16 includes a new migration, don't forget to run spina:install:migrations.
     
     For details on this specific release, refer to the CHANGELOG file.
+    https://github.com/SpinaCMS/Spina/blob/main/CHANGELOG.md#2160-august-23rd-2022
   }
 
   gem.required_ruby_version = ">= 2.7.0"


### PR DESCRIPTION
### Context
Noticed the discrepancy in the post-install message after running bundler. 

### Changes proposed in this pull request
Update the post-install message to indicate the latest version that requires a migration i.e. v2.16.0
https://github.com/Sutter-Health/Spina/blob/main/CHANGELOG.md#2160-august-23rd-2023

### Guidance to review
Nothing should break...
