### PR TITLE
Enable custom title for admin panel - Fixes #1329

### DIFF
--- a/app/views/layouts/spina/admin/application.html.erb
+++ b/app/views/layouts/spina/admin/application.html.erb
@@ -8,7 +8,7 @@
     
     <link rel="icon" href="<%= image_url('spina/favicon.png') %>" />
     
-    <title>Spina CMS</title>
+    <title><%= Spina.config.backend_title %></title>
 
     <!-- Stylesheets -->
     <%= stylesheet_link_tag "spina/tailwind", "spina/fonts", "spina/animate", "data-turbo-track": "reload" %>

--- a/lib/generators/spina/templates/config/initializers/spina.rb
+++ b/lib/generators/spina/templates/config/initializers/spina.rb
@@ -4,6 +4,11 @@ Spina.configure do |config|
   # All locales your content should be available in.
   # Defaults to I18n.default_locale
   # config.locales = [:en, :nl]
+  
+  # Backend title
+  # ===============
+  # Set <title> for the admin panel. Defaults to "Spina CMS"
+  # config.backend_title = "Spina CMS"
 
   # Backend path
   # ===============

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -23,6 +23,7 @@ module Spina
   config_accessor :api_key,
     :api_path,
     :authentication,
+    :backend_title,
     :backend_path,
     :importmap,
     :frontend_parent_controller,
@@ -44,6 +45,7 @@ module Spina
   self.api_key = nil
   self.api_path = "api"
   self.authentication = "Spina::Authentication::Sessions"
+  self.backend_title = "Spina CMS"
   self.backend_path = "admin"
   self.disable_frontend_routes = false
   self.disable_decorator_load = false

--- a/test/dummy/config/initializers/spina.rb
+++ b/test/dummy/config/initializers/spina.rb
@@ -3,6 +3,11 @@ Spina.configure do |config|
   # ===============
   # All locales your content should be available in.
   config.locales = [:en, :nl, :de]
+  
+  # Backend title
+  # ===============
+  # Set <title> for the admin panel. Defaults to "Spina CMS"
+  # config.backend_title = "Spina CMS"
 
   # Backend path
   # ===============


### PR DESCRIPTION
Set `config.backend_title` in `spina.rb` to set a custom <title>-tag for Spina's admin panel. Defaults to "Spina CMS".