### PR TITLE
Hide navigations if none are present in theme config - Fixes #1322

### DIFF
--- a/app/views/spina/admin/shared/_navigation.html.erb
+++ b/app/views/spina/admin/shared/_navigation.html.erb
@@ -16,7 +16,9 @@
         
           <%= render Spina::MainNavigation::LinkComponent.new t('spina.website.pages'), spina.admin_pages_path, active: controller_name.in?(%w(pages resources)) %>
           
-          <%= render Spina::MainNavigation::LinkComponent.new t('spina.navigations.navigations'), spina.admin_navigations_path, active: controller_name == "navigations" %>
+          <% if Spina::Current.theme.navigations.present? %>
+            <%= render Spina::MainNavigation::LinkComponent.new t('spina.navigations.navigations'), spina.admin_navigations_path, active: controller_name == "navigations" %>
+          <% end %>
           
           <% if Spina::Current.theme.layout_parts.present? %>
             <%= render Spina::MainNavigation::LinkComponent.new t('spina.layout.layout'), spina.edit_admin_layout_path, active: controller_name == "layout" %>


### PR DESCRIPTION
If no navigations are present in your theme configuration, just hide the navigations menu in the admin panel.