### PR TITLE
remove importmap shims

### DIFF
--- a/app/helpers/spina/spina_helper.rb
+++ b/app/helpers/spina/spina_helper.rb
@@ -1,10 +1,8 @@
 module Spina::SpinaHelper
-  def spina_importmap_tags(entry_point = "application", shim: true)
+  def spina_importmap_tags(entry_point = "application")
     safe_join [
       javascript_inline_importmap_tag(Spina.config.importmap.to_json(resolver: self)),
       javascript_importmap_module_preload_tags(Spina.config.importmap),
-      (javascript_importmap_shim_nonce_configuration_tag if shim),
-      (javascript_importmap_shim_tag if shim),
       javascript_import_module_tag(entry_point)
     ], "\n"
   end


### PR DESCRIPTION
### Context

Fixes #1358 

### Changes proposed in this pull request

Remove importmap shims entirely.

### Guidance to review

Alternatives considered:

- checking importmap gem version in method
- calling defined? in ternary expression
- pinning Spina's importmap version to v1