### PR TITLE
Support Turbo 8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       sprockets-rails
       stimulus-rails (>= 0.7.0)
       tailwindcss-rails (>= 2.0.0)
-      turbo-rails (>= 0.9, < 2.0)
+      turbo-rails (>= 0.9, < 3.0)
       view_component (>= 2.32, < 4.0)
 
 GEM
@@ -301,7 +301,7 @@ GEM
       railties (>= 6.0.0)
     thor (1.3.0)
     timeout (0.4.1)
-    turbo-rails (1.5.0)
+    turbo-rails (2.0.1)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.license = "MIT"
   gem.post_install_message = %q{
     Spina v2.16 includes a new migration, don't forget to run spina:install:migrations.
-    
+
     For details on this specific release, refer to the CHANGELOG file.
     https://github.com/SpinaCMS/Spina/blob/main/CHANGELOG.md#2160-august-23rd-2022
   }
@@ -46,7 +46,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "attr_json"
   gem.add_dependency "view_component", ">= 2.32", "< 4.0"
   gem.add_dependency "importmap-rails", ">= 0.7.6"
-  gem.add_dependency "turbo-rails", ">= 0.9", "< 2.0"
+  gem.add_dependency "turbo-rails", ">= 0.9", "< 3.0"
   gem.add_dependency "stimulus-rails", ">= 0.7.0"
   gem.add_dependency "babosa"
   gem.add_dependency "jsonapi-serializer"


### PR DESCRIPTION
### Context

I noticed I can't install turbo-rails 2.0 (Turbo 8) on a Spina project of mine due to the gem spec. Even though I've been running the betas on said project without any issues for while. So I pulled the Spina codebase locally, installed turbo-rails 2.0.1 and ran the tests without issue, apparently.

### Changes proposed in this pull request

This relaxes the version requirement for turbo-rails in the gem spec so Spina projects can use the latest and greatest.

### Guidance to review

I'm a novice at Rails so someone other than me should review this before merging. I just ran the test suite in a terminal (including system tests).