### PR TITLE
Add PageLink to the Built-in part list

### DIFF
--- a/lib/generators/spina/templates/config/initializers/themes/default.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/default.rb
@@ -20,6 +20,7 @@ Spina::Theme.register do |theme|
   # - Attachment
   # - Option
   # - Repeater
+  # - PageLink
   theme.parts = [
     {name: "text", title: "Body", hint: "Your main content", part_type: "Spina::Parts::Text"}
   ]

--- a/lib/generators/spina/templates/config/initializers/themes/demo.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/demo.rb
@@ -20,6 +20,7 @@ Spina::Theme.register do |theme|
   # - Attachment
   # - Option
   # - Repeater
+  # - PageLink
   theme.parts = [
     {name: "repeater", title: "Repeater", part_type: "Spina::Parts::Repeater", item_name: "item", parts: %w[line image headline]},
     {name: "line", title: "Line", part_type: "Spina::Parts::Line"},


### PR DESCRIPTION
### Context
The PageLink part is missing on the list of Built-in part types list on the theme.

It is also missing on the left side menu on the docs.
![image](https://github.com/SpinaCMS/Spina/assets/5619209/8c5c7dfc-8c39-413e-a6d6-5bbcaebc0ae4)
