### PR TITLE
Fix view templates hiding based on associated pages being non-deletable

### DIFF
--- a/lib/spina/theme.rb
+++ b/lib/spina/theme.rb
@@ -47,7 +47,6 @@ module Spina
     def new_page_templates(resource: nil)
       page_collection = resource&.name || "main"
       @view_templates.map do |view_template|
-        next if is_custom_undeletable_page?(view_template[:name])
         next if view_template[:exclude_from]&.include?(page_collection)
 
         OpenStruct.new({
@@ -59,11 +58,6 @@ module Spina
       end.compact.sort_by do |page_template|
         [page_template.recommended ? 0 : 1]
       end
-    end
-
-    # Check if view_template is defined as a custom undeletable page
-    def is_custom_undeletable_page?(view_template_name)
-      @custom_pages.any? { |page| page[:view_template] == view_template_name && !page[:deletable] }
     end
   end
 end


### PR DESCRIPTION
### Context

This is a fix for #1241, where view templates which have been associated with non-deletable pages will not appear in view template lists for new pages, or moving pages

Removes the condition that prevents view templates from being available to associate with new or edited pages.

### Changes proposed in this pull request

Remove the 'is associated with a non-deletable page' condition from the `new_page_templates` method

### Guidance to review

This may be considered a breaking change, since existing view templates would need to update their `exclude_from` array in order to be hidden in the view templates list