### PR TITLE
Add a with_library_path scope to Attachable

### DIFF
--- a/app/models/concerns/spina/attachable.rb
+++ b/app/models/concerns/spina/attachable.rb
@@ -11,6 +11,25 @@ module Spina
           "%" + Image.sanitize_sql_like(query) + "%"
         )
       end
+
+      scope :with_library_path, ->(query) do
+        folder_name, file_name = query.split("/")
+        unless file_name
+          file_name = folder_name
+          folder_name = nil
+        end
+  
+        relation = joins(:file_blob).where(
+          "active_storage_blobs.filename ILIKE ?",
+          "%" + Image.sanitize_sql_like(file_name) + "%"
+        )
+  
+        if folder_name
+          relation.joins(:media_folder).where("spina_media_folders.name = ?", folder_name)
+        else
+          relation
+        end
+      end
     end
     
     def name


### PR DESCRIPTION
### Context
I'm working on markdown support for Spina. To show images from the library I want them to be included with this easy syntax: `![Alt](foldername/imagename)` within the markdown.

### Changes proposed in this pull request
This scope on Attachable helps to fetch the right images based on that syntax.

### Guidance to review
Right now Spina doesn't use this scope internally. So I can see how this might not be accepted at the time. Also it's still using `ILIKE` because that's what the `main` branch does. Will change it once you merge the sql PR.