### PR TITLE
fix: Continuous additions of tailwind config to gitinore

### DIFF
--- a/lib/generators/spina/tailwind_config_generator.rb
+++ b/lib/generators/spina/tailwind_config_generator.rb
@@ -2,14 +2,21 @@ module Spina
   class TailwindConfigGenerator < Rails::Generators::Base
     source_root File.expand_path("../templates", __FILE__)
 
-    def create_tailwind_config_file
-      filename = "app/assets/config/spina/tailwind.config.js"
-      template filename
-      insert_into_file ".gitignore", <<~TEXT
+    CONFIG_FILE = "app/assets/config/spina/tailwind.config.js"
+    IGNORE_TEXT = <<~TEXT.chomp
+      # Ignore auto-generated Spina Tailwind CSS configuration
+      /#{CONFIG_FILE}
+    TEXT
 
-        # Ignore auto-generated Spina Tailwind CSS configuration
-        /#{filename}
-      TEXT
+    def create_tailwind_config_file
+      template CONFIG_FILE
+
+      unless File.read(".gitignore").include?(IGNORE_TEXT)
+        append_to_file ".gitignore", <<~TEXT
+          \n
+          #{IGNORE_TEXT}
+        TEXT
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Since `rails spina:tailwind:watch` uses the config generator, when ran it continues to make additions to your `.gitignore`.

### Changes proposed in this pull request

This change checks to see if the `.gitignore` contains spina's tailwind config file before making a decision to add it.
