### PR TITLE
Depracation warning for Rails 7.2 fixed - enum

### DIFF
--- a/app/models/spina/navigation_item.rb
+++ b/app/models/spina/navigation_item.rb
@@ -6,7 +6,11 @@ module Spina
     # NavigationItems can be of two different kinds:
     # - A link to a page
     # - A link to a URL
-    enum :kind, {page: "page", url: "url"}, suffix: true
+    if Rails.version >= '7.2'
+      enum :kind, {page: "page", url: "url"}, suffix: true
+    else
+      enum kind: {page: "page", url: "url"}, _suffix: true
+    end
 
     has_ancestry
 

--- a/app/models/spina/navigation_item.rb
+++ b/app/models/spina/navigation_item.rb
@@ -6,7 +6,7 @@ module Spina
     # NavigationItems can be of two different kinds:
     # - A link to a page
     # - A link to a URL
-    enum kind: {page: "page", url: "url"}, _suffix: true
+    enum :kind, {page: "page", url: "url"}, suffix: true
 
     has_ancestry
 


### PR DESCRIPTION
### Context

When I use Rails 7.2.X then the following deprecation warning is listed:

> Defining enums with keyword arguments is deprecated and will be removed in Rails 8.0

### Changes proposed in this pull request

Add a switch for the new Rails version to support the new enum syntax

### Guidance to review

The deprecation warning is no longer listed