### PR TITLE
fix: Use Tailwindcss::Ruby executable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ PATH
       rails (>= 6.0)
       sprockets-rails
       stimulus-rails (>= 0.7.0)
-      tailwindcss-rails (>= 2.0.0)
+      tailwindcss-ruby
       turbo-rails (>= 0.9, < 3.0)
       view_component (>= 2.32, < 4.0)
 
@@ -297,8 +297,7 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
-    tailwindcss-rails (2.2.1)
-      railties (>= 6.0.0)
+    tailwindcss-ruby (3.4.14)
     thor (1.3.0)
     timeout (0.4.1)
     turbo-rails (2.0.1)

--- a/lib/tasks/tailwind.rake
+++ b/lib/tasks/tailwind.rake
@@ -1,20 +1,28 @@
-require "tailwindcss-rails"
+require "tailwindcss/ruby"
 
 namespace :spina do
   namespace :tailwind do
     def spina_tailwind_compile_command
-      "#{Tailwindcss::Engine.root.join("exe/tailwindcss")} -i #{Spina::Engine.root.join("app/assets/stylesheets/spina/application.tailwind.css")} -o #{Rails.root.join("app/assets/builds", "spina/tailwind.css")} -c #{Rails.root.join("app/assets/config/spina/tailwind.config.js")}"
+      [
+        Tailwindcss::Ruby.executable,
+        "-i", Spina::Engine.root.join("app/assets/stylesheets/spina/application.tailwind.css").to_s,
+        "-o", Rails.root.join("app/assets/builds/spina/tailwind.css").to_s,
+        "-c", Rails.root.join("app/assets/config/spina/tailwind.config.js").to_s,
+      ]
     end
 
     desc "Build your Tailwind CSS"
     task build: :environment do
       Rails::Generators.invoke("spina:tailwind_config", ["--force"])
-      system spina_tailwind_compile_command
+      command = spina_tailwind_compile_command
+      system *command
     end
 
     task watch: :environment do
       Rails::Generators.invoke("spina:tailwind_config", ["--force"])
-      system "#{spina_tailwind_compile_command} -w"
+      command = spina_tailwind_compile_command
+      command << "-w"
+      system *command
     end
   end
 end

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -51,5 +51,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "babosa"
   gem.add_dependency "jsonapi-serializer"
   gem.add_dependency "browser"
-  gem.add_dependency "tailwindcss-rails", ">= 2.0.0"
+  gem.add_dependency "tailwindcss-ruby"
 end


### PR DESCRIPTION
### Context
`Tailwindcss::Engine.root` is not the location of the executable anymore. We can utilize `Tailwindcss::Ruby.executable` the same way th

### Changes proposed in this pull request
We can utilize `Tailwindcss::Ruby.executable` the same way that [`tailwindcss-rails`](https://github.com/rails/tailwindcss-rails) does.
