### PR TITLE
Allow links to YouTube Shorts in YouTube Embed

### DIFF
--- a/app/models/spina/embeds/youtube.rb
+++ b/app/models/spina/embeds/youtube.rb
@@ -6,7 +6,7 @@ module Spina::Embeds
 
     heroicon "video-camera"
 
-    REGEX = /(?:youtube(?:-nocookie)?\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+    REGEX = /(?:youtube(?:-nocookie)?\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|shorts\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
 
     validates :url, presence: true, format: {with: REGEX}
 


### PR DESCRIPTION
Support YouTube shorts. The embed markup works without changes.