### PR TITLE
Update to v2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.20
 
-### Unreleased
+### 2.20.0 (May 5th, 2025)
 * Added support for Rails 8 
 * Added support for Propshaft
 * Added support for Youtube Shorts in Youtube Embeds

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina (2.19.0)
+    spina (2.20.0)
       ancestry
       attr_json
       babosa

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,3 +1,3 @@
 module Spina
-  VERSION = "2.19.0"
+  VERSION = "2.20.0"
 end


### PR DESCRIPTION
# Changelog

* Added support for Rails 8 
* Added support for Propshaft
* Added support for Youtube Shorts in Youtube Embeds
* Fixed translations
* Updated gem dependencies 

(remember to run `bin/rails spina:install:migrations`)

