### PR TITLE
fix: Use named deprecator

### DIFF
--- a/app/controllers/concerns/spina/current_spina_account.rb
+++ b/app/controllers/concerns/spina/current_spina_account.rb
@@ -11,7 +11,7 @@ module Spina
     private
 
     def current_account
-      ActiveSupport::Deprecation.warn(
+      Spina.deprecator.warn(
         "#current_account is deprecated, due to a common authentication namespace conflict. \n" \
         "Please use #current_spina_account instead."
       )

--- a/app/models/spina/account.rb
+++ b/app/models/spina/account.rb
@@ -23,7 +23,7 @@ module Spina
       args.each do |method_name|
         define_method method_name do
           if preferences.try(:[], method_name.to_sym).present?
-            ActiveSupport::Deprecation.warn("#{method_name} is stored as a symbol. Please set and save it again using #{method_name}= on your Spina::Account model to store it as a string. You can do this from the UI by saving your account preferences.")
+            Spina.deprecator.warn("#{method_name} is stored as a symbol. Please set and save it again using #{method_name}= on your Spina::Account model to store it as a string. You can do this from the UI by saving your account preferences.")
           end
 
           preferences.try(:[], method_name.to_s) ||
@@ -78,7 +78,7 @@ module Spina
           parent_page = Page.find_by(name: page[:parent])
           ancestry = [parent_page&.ancestry, parent_page&.id].compact.join("/")
         end
-        
+
         Page.where(name: page[:name])
           .first_or_create(title: page[:title])
           .update(view_template: page[:view_template], deletable: page[:deletable], ancestry: ancestry)

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -90,24 +90,28 @@ module Spina
       config_obj = config_original
 
       def config_obj.tailwind_purge_content
-        ActiveSupport::Deprecation.warn("config.tailwind_purge_content has been renamed to config.tailwind_content")
+        deprecator.warn("config.tailwind_purge_content has been renamed to config.tailwind_content")
         tailwind_content
       end
 
       def config_obj.tailwind_purge_content=(paths)
-        ActiveSupport::Deprecation.warn("config.tailwind_purge_content has been renamed to config.tailwind_content")
+        deprecator.warn("config.tailwind_purge_content has been renamed to config.tailwind_content")
         self.tailwind_content = paths
       end
 
       def config_obj.embedded_image_size=(image_size)
         if image_size.is_a? String
-          ActiveSupport::Deprecation.warn("Spina embedded_image_size should be set to an array of arguments to be passed to the :resize_to_limit ImageProcessing macro. https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit")
+          deprecator.warn("Spina embedded_image_size should be set to an array of arguments to be passed to the :resize_to_limit ImageProcessing macro. https://github.com/janko/image_processing/blob/master/doc/minimagick.md#resize_to_limit")
         end
 
         self[:embedded_image_size] = image_size
       end
 
       config_obj
+    end
+
+    def deprecator
+      ActiveSupport::Deprecation.new("", "Spina")
     end
 
     def mounted_at

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -21,7 +21,7 @@ module Spina
     config.to_prepare do
       unless Spina.config.disable_decorator_load
         Dir.glob(Rails.root + "app/decorators/**/*_decorator.rb").each do |decorator|
-          ActiveSupport::Deprecation.warn("using app/decorators is deprecated in favor of app/overrides. Read more about overriding Spina at spinacms.com/guides")
+          Spina.deprecator.warn("using app/decorators is deprecated in favor of app/overrides. Read more about overriding Spina at spinacms.com/guides")
           require_dependency(decorator)
         end
       end


### PR DESCRIPTION
### Context

`ActiveSupport::Deprecation.warn` is no longer a public method

### Changes proposed in this pull request

Use the documented way by Rails to use a deprecator in an engine

This also should take care of the stalebot closed #1384
