### PR TITLE
Bump allowable view component versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ PATH
       stimulus-rails (>= 0.7.0)
       tailwindcss-ruby
       turbo-rails (>= 0.9, < 3.0)
-      view_component (>= 2.32, < 4.0)
+      view_component (>= 2.32, < 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mobility", ">= 1.3.0"
   gem.add_dependency "rack-rewrite", ">= 1.5.0"
   gem.add_dependency "attr_json"
-  gem.add_dependency "view_component", ">= 2.32", "< 4.0"
+  gem.add_dependency "view_component", ">= 2.32", "< 5.0"
   gem.add_dependency "importmap-rails", ">= 0.7.6"
   gem.add_dependency "turbo-rails", ">= 0.9", "< 3.0"
   gem.add_dependency "stimulus-rails", ">= 0.7.0"


### PR DESCRIPTION
### Context

Upgrading to Rails 8.1 requires the 4.1 version of the view_component gem. The current Spina gemset does not allow this version.

### Changes proposed in this pull request
Allow this version

### Guidance to review
Replaced with `<5`, which seems reasonable, but perhaps you'd prefer to be more pessimistic and only allow up to `<4.1`.
