### PR TITLE
Make migration reversible

### DIFF
--- a/db/migrate/5_remove_translated_columns.rb
+++ b/db/migrate/5_remove_translated_columns.rb
@@ -1,11 +1,11 @@
 class RemoveTranslatedColumns < ActiveRecord::Migration[5.0]
   def change
-    remove_column :spina_lines, :content
-    remove_column :spina_texts, :content
-    remove_column :spina_pages, :title
-    remove_column :spina_pages, :menu_title
-    remove_column :spina_pages, :description
-    remove_column :spina_pages, :seo_title
-    remove_column :spina_pages, :materialized_path
+    remove_column :spina_lines, :content, :string
+    remove_column :spina_texts, :content, :text
+    remove_column :spina_pages, :title, :string
+    remove_column :spina_pages, :menu_title, :string
+    remove_column :spina_pages, :description, :text
+    remove_column :spina_pages, :seo_title, :string
+    remove_column :spina_pages, :materialized_path, :string
   end
 end


### PR DESCRIPTION
Fixes #1422 This pull request updates the migration file `db/migrate/5_remove_translated_columns.rb` to specify the column types when removing columns.

### Context
The migration previously could not be rolled back

### Changes proposed in this pull request
The migration can now be rolled back

### Guidance to review
Run `rails spina:install` on a new project, then rollback the migrations. They should all rollback cleanly.