### PR TITLE
Feature: Markdown page part

### DIFF
--- a/app/models/spina/parts/markdown.rb
+++ b/app/models/spina/parts/markdown.rb
@@ -1,0 +1,11 @@
+module Spina
+  module Parts
+    class Markdown < Base
+      attr_json :content, :string, default: ""
+
+      def to_html
+        Kramdown::Document.new(content.to_s).to_html.html_safe
+      end
+    end
+  end
+end

--- a/app/presenters/spina/content_presenter.rb
+++ b/app/presenters/spina/content_presenter.rb
@@ -17,6 +17,10 @@ module Spina
       RichTextPresenter.new(view_context, html)
     end
 
+    def markdown(name)
+      Kramdown::Document.new(find_part(name)&.content.to_s).to_html.html_safe
+    end
+
     def image_tag(image, variant_options = {}, options = {})
       image = find_part(image) unless image.is_a? Spina::Parts::Image
       image_tag_options = {alt: image&.alt}

--- a/app/views/spina/admin/parts/markdowns/_form.html.erb
+++ b/app/views/spina/admin/parts/markdowns/_form.html.erb
@@ -1,0 +1,7 @@
+<div class="mt-6">
+  <label for="content" class="block text-sm leading-5 font-medium text-gray-700"><%= f.object.title %></label>
+  <div class="text-gray-400 text-sm"><%= f.object.hint || "Markdown formatting supported" %></div>
+  <div class="mt-1">
+    <%= f.text_area :content, placeholder: f.object.title, class: "form-input mt-1 w-full font-mono text-sm", rows: 10 %>
+  </div>
+</div>

--- a/docs/v2/themes/1_parts.md
+++ b/docs/v2/themes/1_parts.md
@@ -9,6 +9,7 @@ A page in Spina has many parts. By default these parts can be one of the followi
 - Spina::Parts::ImageCollection
 - Spina::Parts::Repeater
 - Spina::Parts::Option
+- Spina::Parts::Markdown
 
 These are the building blocks of your view templates. You can have an unlimited number of parts in a page. We prefer to keep the number of parts to a minimum so that managing your pages isn't too complex.
 

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -11,6 +11,7 @@ require "attr_json"
 require "view_component"
 require "jsonapi/serializer"
 require "browser"
+require "kramdown"
 
 module Spina
   class Engine < ::Rails::Engine
@@ -38,7 +39,8 @@ module Spina
         Spina::Parts::Option,
         Spina::Parts::Attachment,
         Spina::Parts::PageLink,
-        Spina::Parts::ResourceLink
+        Spina::Parts::ResourceLink,
+        Spina::Parts::Markdown
       )
     end
   end

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "jsonapi-serializer"
   gem.add_dependency "browser"
   gem.add_dependency "tailwindcss-ruby", ">= 4.0"
+  gem.add_dependency "kramdown"
 end


### PR DESCRIPTION
### Context

Some users may prefer to write formatting in Markdown as an alternative to the Trix editor formatting.

### Changes proposed in this pull request

Add a Markdown page part to be included with Spina's default set of available page parts.

### Guidance to review

For including this in your Spina pages:
```ruby
# config/initializers/themes/default.rb
  theme.parts = [
    {name: "markdown", title: "Markdown section", part_type: "Spina::Parts::Markdown"},
  ]

  theme.view_templates = [
    {name: "page_parts_demo", title: "Page Parts Demo", parts: %w[markdown]}
  ]

# views/default/pages/page_parts_demo.html.erb
<h1><%= current_page.title %></h1>
<div class="pt-5">
  <%= content.markdown(:markdown) %>
</div>
```

It uses Kramdown as the Markdown rendering engine. If requested, I can add a setting that would allow the user to choose a different Markdown processor. Such a setting would allow even greater flexibility.

<img width="1920" height="748" alt="spina-markdown-component" src="https://github.com/user-attachments/assets/7773b90e-d7b3-4e94-9c9a-99c410681e09" />
