### PR TITLE
Allow embeddables to be blank

### DIFF
--- a/app/controllers/spina/admin/embeds_controller.rb
+++ b/app/controllers/spina/admin/embeds_controller.rb
@@ -27,7 +27,7 @@ module Spina
       end
 
       def embed_params
-        params.permit(:embeddable).fetch(:embeddable, {})
+        params.permit(embeddable: {}).fetch(:embeddable, {})
       end
     end
   end

--- a/app/controllers/spina/admin/embeds_controller.rb
+++ b/app/controllers/spina/admin/embeds_controller.rb
@@ -27,7 +27,7 @@ module Spina
       end
 
       def embed_params
-        params.require(:embeddable).permit!
+        params.permit(:embeddable).fetch(:embeddable, {})
       end
     end
   end

--- a/test/functional/spina/admin/embeds_controller_test.rb
+++ b/test/functional/spina/admin/embeds_controller_test.rb
@@ -7,6 +7,7 @@ module Spina
         @routes = Spina::Engine.routes
         @account = FactoryBot.create(:account)
         @user = FactoryBot.create(:user)
+        @controller.stubs(:current_spina_user).returns(@user)
       end
 
       test "should work with normal nested embeddable params" do

--- a/test/functional/spina/admin/embeds_controller_test.rb
+++ b/test/functional/spina/admin/embeds_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+module Spina
+  module Admin
+    class EmbedsControllerTest < ActionController::TestCase
+      setup do
+        @routes = Spina::Engine.routes
+        @account = FactoryBot.create(:account)
+        @user = FactoryBot.create(:user)
+        sign_in @user
+      end
+
+      test "should work with normal nested embeddable params" do
+        post :create, params: {
+          embed_type: "Spina::Embeds::YouTube",
+          embeddable: {
+            url: "https://www.youtube.com/watch?v=dQw4w9wgxcq"
+          }
+        }, format: :turbo_stream
+
+        assert_response :success
+      end
+
+      test "should create embeddable with no attributes (no embeddable param sent)" do
+        post :create, params: {
+          embed_type: "Spina::Embeds::YouTube"
+        }, format: :turbo_stream
+
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/spina/admin/embeds_controller_test.rb
+++ b/test/functional/spina/admin/embeds_controller_test.rb
@@ -7,7 +7,6 @@ module Spina
         @routes = Spina::Engine.routes
         @account = FactoryBot.create(:account)
         @user = FactoryBot.create(:user)
-        sign_in @user
       end
 
       test "should work with normal nested embeddable params" do


### PR DESCRIPTION
to support embeddables without any attributes.

### Context

https://github.com/SpinaCMS/Spina/issues/1433

### Changes proposed in this pull request

loosen the strong params with `params.permit(embeddable: {}).fetch(:embeddable, {})`

### Guidance to review

Million ways to skin this cat, this was just my take on it.