### PR TITLE
Allows embeds to not have any attributes

### DIFF
--- a/app/controllers/spina/admin/embeds_controller.rb
+++ b/app/controllers/spina/admin/embeds_controller.rb
@@ -27,7 +27,7 @@ module Spina
       end
 
       def embed_params
-        params.require(:embeddable).permit!
+        params.permit(embeddable: {}).fetch(:embeddable, {})
       end
     end
   end

--- a/test/functional/spina/admin/embeds_controller_test.rb
+++ b/test/functional/spina/admin/embeds_controller_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+module Spina::Embeds
+  class Attributeless < Base
+    def to_trix_partial_path 
+      nil
+    end
+    def to_trix_attachment 
+      "<div>Attributeless embed</div>"
+    end
+  end
+end
+
+module Spina
+  module Admin
+    class EmbedsControllerTest < ActionController::TestCase
+      setup do
+        @routes = Spina::Engine.routes
+        @account = FactoryBot.create(:account)
+        @user = FactoryBot.create(:user)
+        @controller.stubs(:current_spina_user).returns(@user)
+      end
+
+      test "should work with normal nested embeddable params" do
+        post :create, params: {
+          embed_type: "Spina::Embeds::Youtube",
+          embeddable: {
+            url: "https://www.youtube.com/watch?v=dQw4w9wgxcq"
+          }
+        }, format: :turbo_stream
+
+        assert_response :success
+      end
+
+      test "should create embeddable with no attributes" do
+        post :create, params: {
+          embed_type: "Spina::Embeds::Attributeless"
+        }, format: :turbo_stream
+
+        assert_response :success
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://github.com/SpinaCMS/Spina/issues/1433

### Changes proposed in this pull request
loosen the strong params with `params.permit(embeddable: {}).fetch(:embeddable, {})`

### Guidance to review
I think I got the tests working now 🤞
