### PR TITLE
Define page templates and layout parts in dedicated Ruby files

### DIFF
--- a/app/controllers/spina/admin/layout_controller.rb
+++ b/app/controllers/spina/admin/layout_controller.rb
@@ -3,6 +3,7 @@ module Spina::Admin
     before_action :set_account
     before_action :set_locale
     before_action :set_breadcrumb
+    before_action :set_parts_context
     before_action :get_layout_parts
 
     admin_section :content
@@ -41,6 +42,10 @@ module Spina::Admin
 
     def set_locale
       @locale = params[:locale] || I18n.default_locale
+    end
+
+    def set_parts_context
+      @parts_context = :layout
     end
   end
 end

--- a/app/helpers/spina/admin/pages_helper.rb
+++ b/app/helpers/spina/admin/pages_helper.rb
@@ -8,13 +8,27 @@ module Spina::Admin
       end
     end
 
-    def build_parts(partable, parts)
+    def build_parts(partable, parts, context: parts_context_for(partable))
       I18n.with_locale(@locale) do
         parts.map do |part|
-          part_attributes = current_theme.parts.find { |p| p[:name].to_s == part.to_s }
+          part_attributes = find_part_definition(part, context: context, view_template: current_view_template)
           partable.part(part_attributes)
         end
       end
+    end
+
+    def find_part_definition(name, context: parts_context, view_template: current_view_template)
+      Spina::Current.theme.part_definitions_for(context, view_template: view_template).find do |part|
+        part[:name].to_s == name.to_s
+      end
+    end
+
+    def current_view_template
+      @page&.view_template
+    end
+
+    def parts_context
+      @parts_context ||= :page
     end
 
     def parts_partial_namespace(part_type)
@@ -27,21 +41,24 @@ module Spina::Admin
 
     private
 
-      def check_propshaft_asset(path)
-        if Rails.configuration.assets.compile
-          Rails.application.assets.load_path.find(path).present? rescue false
-        else
-          Rails.application.assets.asset_for(path).present? rescue false
-        end
-      end
+    def parts_context_for(partable)
+      partable.is_a?(Spina::Account) ? :layout : parts_context
+    end
 
-      def check_sprockets_asset(path)
-        if Rails.configuration.assets.compile
-          Rails.application.precompiled_assets.include?(path)
-        else
-          Rails.application.assets_manifest.assets[path].present?
-        end
+    def check_propshaft_asset(path)
+      if Rails.configuration.assets.compile
+        Rails.application.assets.load_path.find(path).present? rescue false
+      else
+        Rails.application.assets.asset_for(path).present? rescue false
       end
+    end
 
+    def check_sprockets_asset(path)
+      if Rails.configuration.assets.compile
+        Rails.application.precompiled_assets.include?(path)
+      else
+        Rails.application.assets_manifest.assets[path].present?
+      end
+    end
   end
 end

--- a/app/views/spina/admin/parts/repeaters/_fields.html.erb
+++ b/app/views/spina/admin/parts/repeaters/_fields.html.erb
@@ -2,7 +2,7 @@
   <%= f.hidden_field :title %>
   <%= f.hidden_field :name %>
 
-  <% parts = current_theme.parts.find{|p|p[:name].to_s == f.object.name.to_s}&.dig(:parts) || [] %>
+  <% parts = find_part_definition(f.object.name)&.dig(:parts) || [] %>
 
   <%= f.fields_for :parts, build_parts(f.object, parts) do |ff| %>
     <%= ff.hidden_field :title %>

--- a/docs/v2/2_themes.md
+++ b/docs/v2/2_themes.md
@@ -2,4 +2,11 @@
 
 The installer generates a few initializers that contain necessary configuration for Spina.
 
-In the initializers folder there's a new folder named themes. Inside you will find a configuration file named default.rb. This file contains all of your theme-specific settings. You can define multiple parts, view templates and custom pages.
+In the initializers folder there's a new folder named themes. Inside you will find a configuration file named default.rb. This file contains your theme's global settings: custom pages, navigations, embeds, and so on.
+
+Page and layout part definitions live in `app/templates/spina/default/`:
+
+- `layout.rb` — global layout parts (`Spina.define_layout_parts`)
+- `homepage.rb`, `show.rb`, etc. — page type definitions (`Spina.define_template`)
+
+See [Parts](themes/1_parts.md), [View templates](themes/2_view_templates.md), and [Layout parts](themes/3_layout_parts.md) for details.

--- a/docs/v2/getting_started/4_upgrading.md
+++ b/docs/v2/getting_started/4_upgrading.md
@@ -1,5 +1,30 @@
 # Upgrading
 
+# Migrating theme configuration to page template files
+
+Defining `theme.parts` and `theme.view_templates` directly in your theme initializer is deprecated and will be removed in a future major version of Spina.
+
+The new style moves part definitions into `app/templates/spina/your_theme/`:
+
+- `layout.rb` for global layout parts
+- one file per page type (e.g. `homepage.rb`, `show.rb`)
+
+To migrate automatically:
+
+```bash
+bin/rails spina:theme:migrate_templates[default]
+```
+
+This will:
+
+1. Generate page template files under `app/templates/spina/default/`
+2. Generate `layout.rb` if your theme has layout parts (including sectioned/tabbed layout parts)
+
+3. Replace your theme initializer with a slim version
+4. Back up the original to `config/initializers/themes/default.rb.bak`
+
+If you have both the old configuration and template files present, Spina will raise an error at boot. Remove `theme.parts` and `theme.view_templates` from your theme initializer, or run the migrator.
+
 # Upgrading from v2.0 to v2.1
 
 v2.1 is a big upgrade for Spina's interface. All JavaScript, CSS and views have been refactored. Gone are jQuery, Turbolinks, custom stylesheets and Haml. 

--- a/docs/v2/rendering_content/3_rich_text.md
+++ b/docs/v2/rendering_content/3_rich_text.md
@@ -6,15 +6,13 @@ This part returns HTML. You can use the following helper to render it as HTML:
 
 ## Theme configuration
 
-```
-config.parts = [
-  # ...
-  {
-    name: "main_content",
-    title: "Main content",
-    part_type: "Spina::Parts::Text"
-  }
-]
+Define text parts in your page template file:
+
+```ruby
+# app/templates/spina/default/show.rb
+Spina.define_template :show do
+  part :main_content, :text, title: "Main content"
+end
 ```
 
 ## View template example

--- a/docs/v2/rendering_content/8_repeating_content.md
+++ b/docs/v2/rendering_content/8_repeating_content.md
@@ -4,18 +4,16 @@ Nesting content is a very powerful feature of Spina. In your theme config you ca
 
 ## Theme configuration
 
-```
-config.parts = [
-  # ...
-  { name: "title", title: "Title", part_type: "Spina::Parts::Line" }, 
-  { name: "image", title: "Image", part_type: "Spina::Parts::Image" }, 
-  {
-    name: "portfolio",
-    title: "Portfolio",
-    parts: %w(title image),
-    part_type: "Spina::Parts::Repeater"
-  }
-]
+Define repeating content in your page template file:
+
+```ruby
+# app/templates/spina/default/show.rb
+Spina.define_template :show do
+  repeater :portfolio do
+    part :title, :line
+    part :image, :image
+  end
+end
 ```
 
 ## View template example

--- a/docs/v2/themes/1_parts.md
+++ b/docs/v2/themes/1_parts.md
@@ -12,89 +12,85 @@ A page in Spina has many parts. By default these parts can be one of the followi
 
 These are the building blocks of your view templates. You can have an unlimited number of parts in a page. We prefer to keep the number of parts to a minimum so that managing your pages isn't too complex.
 
-Spina uses an initializer to create the basic building blocks of your page. There are three steps to add a new building block or part to your app:
+Parts are defined in page template files under `app/templates/spina/your_theme/`. There are three steps to add a new part to your app:
 
-- Set up a new part in the initializer
-- Set the new initializer into a view template
+- Define the part in a page template file
 - Add it to the view
 
-**Create a new page part**
+## Theme configuration
 
-When you install Spina, you will see the following in config/initializers/themes/default.rb
+Your theme initializer only contains global theme settings:
 
 ```ruby
+# config/initializers/themes/default.rb
 Spina::Theme.register do |theme|
-  theme.name = 'default'
-  theme.title = 'Default theme'
-  
-  theme.parts = [
-    {name: 'text',  title: "Body", hint: "Your main content", part_type: "Spina::Parts::Text"}
-  ]
-  
-  theme.view_templates = [
-    {name: 'homepage', title: 'Homepage', parts: %w(text)}, 
-    {name: 'show', title: 'Page', parts: %w(text)}
-  ]
-  
+  theme.name = "default"
+  theme.title = "Default theme"
+
   theme.custom_pages = [
-    {name: 'homepage', title: "Homepage", deletable: false, view_template: "homepage"},
+    {name: "homepage", title: "Homepage", deletable: false, view_template: "homepage"}
   ]
 
   theme.navigations = [
-    {name: 'main', label: 'Main navigation'}
+    {name: "main", label: "Main navigation"}
   ]
-  
-  theme.layout_parts = []
-  theme.resources = []
-  theme.plugins = []
+
   theme.embeds = []
 end
-
 ```
 
-Right now, the default theme is applying a title to the page, with a simple text div below it. Go to /admin on your app and have a look. Edit the textbox and go to preview the page.
+Page templates are loaded automatically from `app/templates/spina/default/`.
 
-Let's say I wanted to add another text box below this called portfolio. First I would add another hash to the parts array like so:
+## Create a new page part
+
+When you install Spina, you will see page template files like this:
 
 ```ruby
-theme.parts = [{
-  name:         'content',
-  title:        'Content',
-  part_type:    'Spina::Parts::Text'
-}, {
-  name:         'portfolio', # added this part
-  title:        'Portfolio',
-  part_type:    'Spina::Parts::Text'
-}]
+# app/templates/spina/default/show.rb
+Spina.define_template :show do
+  title "Page"
+  part :text, :text, title: "Body", hint: "Your main content"
+end
 ```
 
-**Add it to the view template**
-
-Now, we need to update the view_templates config. These view templates provide customization for the different views you might want. For example, you may have a 'blog' view or an 'about' view which add different parts. For this example we will add the portfolio part into the 'Default' view template.
+Built-in part types can be referenced as symbols (`:line`, `:text`, `:image`, and so on). Custom or extension parts use the full class name as a string:
 
 ```ruby
-theme.view_templates = [{
-  name:  'homepage',
-  title: 'Homepage',
-  parts: %w(content)
-}, {
-  name:         'show',
-  title:        'Default',
-  description:  'A simple page',
-  usage:        'Use for your content',
-  parts:        %w(content portfolio) # added 'portfolio'
-}]
+part :case_study, "MyApp::Parts::CaseStudy"
 ```
 
-**Add it to the view**
+Let's say you wanted to add another text box below the body called portfolio. Update the page template:
 
-Finally, let's go to views/default/pages/show.html.erb and add the following:
+```ruby
+# app/templates/spina/default/show.rb
+Spina.define_template :show do
+  title "Page"
+  part :text, :text, title: "Body", hint: "Your main content"
+  part :portfolio, :text, title: "Portfolio"
+end
+```
+
+## Add it to the view
+
+Finally, go to `app/views/default/pages/show.html.erb` and add:
 
 ```erb
 <h1><%= current_page.title %></h1>
 
 <%= content.html :text %>
-<%= content.html :portfolio %> # added this line
+<%= content.html :portfolio %>
 ```
 
-We have successfully added another textbox! Refresh the page form in the admin section. You should see another text box below the content box.
+Refresh the page form in the admin section. You should see another text box below the content box.
+
+## Migrating from the old configuration style
+
+Previously, all parts were defined in the theme initializer using `theme.parts` and `theme.view_templates`. That style still works, but is deprecated and will be removed in a future major version of Spina.
+
+To migrate an existing theme automatically:
+
+```bash
+bin/rails spina:theme:migrate_templates[default]
+```
+
+This generates page template files, creates `layout.rb` if needed, and replaces your theme initializer with a slim version. Your original file is backed up to `config/initializers/themes/default.rb.bak`.

--- a/docs/v2/themes/2_view_templates.md
+++ b/docs/v2/themes/2_view_templates.md
@@ -2,4 +2,58 @@
 
 Each theme typically has a few different view templates which make up your website. By default Spina generates a homepage and show template.
 
-The views for these templates are stored in app/views/default/pages.
+View templates are defined as Ruby files in `app/templates/spina/your_theme/`:
+
+```ruby
+# app/templates/spina/default/homepage.rb
+Spina.define_template :homepage do
+  title "Homepage"
+  description "The front page of your website"
+
+  part :headline, :line
+  part :body, :text
+  part :hero_image, :image
+end
+```
+
+The views for these templates are stored in `app/views/default/pages/`.
+
+## Repeating content
+
+Use a `repeater` block for nested content:
+
+```ruby
+Spina.define_template :show do
+  title "Page"
+
+  repeater :portfolio do
+    part :title, :line
+    part :image, :image
+    part :description, :text
+  end
+end
+```
+
+## Template metadata
+
+You can set additional options on a page template:
+
+```ruby
+Spina.define_template :blogpost do
+  title "Blogpost"
+  description "Article template"
+  usage "Use for blog articles"
+  exclude_from %w[main]
+  layout "article"
+end
+```
+
+## Custom template path
+
+By default, Spina loads templates from `app/templates/spina/{theme.name}/`. You can override this in your theme initializer:
+
+```ruby
+theme.load_templates_from "app/templates/spina/default"
+```
+
+In development, Spina watches `config/initializers/themes/` and `app/templates/` (recursively) so new or changed template files reload automatically. Custom `load_templates_from` directories outside `app/templates/` are also watched after the theme registers.

--- a/docs/v2/themes/3_layout_parts.md
+++ b/docs/v2/themes/3_layout_parts.md
@@ -1,17 +1,42 @@
 # Layout parts
 
-Just like adding parts to view_templates you can also add parts you want to use globally throughout your website. These are called `layout_parts` and you can set them up like this:
+Layout parts are editable content that belongs to your website as a whole, rather than to a single page. This content is stored on the `Spina::Account` model and can be rendered with `current_spina_account.content`.
+
+Define layout parts in `app/templates/spina/your_theme/layout.rb`:
 
 ```ruby
-::Spina::Theme.register do |theme|
-  theme.parts = [{
-    name:       'footer',
-    title:      'Footer',
-    part_type:  'Spina::Parts::Text'
-  }]
-  # ...
-  theme.layout_parts = %w(footer)
+# app/templates/spina/default/layout.rb
+Spina.define_layout_parts do
+  part :footer, :text, title: "Footer"
+  part :tag_line, :line
 end
 ```
 
-This content is stored on the `Spina::Account` model. You can use `current_spina_account.content` to render layout parts in your frontend.
+Spina automatically sets `theme.layout_parts` from the parts defined in this file.
+
+## Sections
+
+The Layout screen can split parts into tabs. Express that with `section` blocks:
+
+```ruby
+Spina.define_layout_parts do
+  section :general do
+    part :footer, :text
+    part :logo, :image
+  end
+
+  section :seo do
+    part :meta_title, :line
+  end
+end
+```
+
+Tab labels use `I18n` keys under `spina.layout.sections.<name>`. You cannot mix top-level parts with sections in the same file.
+
+## Rendering layout parts
+
+```erb
+<%= current_spina_account.content.html :footer %>
+```
+
+If you need a part to appear on the layout but not on any page type, define it only in `layout.rb`.

--- a/lib/generators/spina/install_generator.rb
+++ b/lib/generators/spina/install_generator.rb
@@ -64,6 +64,7 @@ module Spina
         template "config/initializers/themes/#{theme}.rb"
         directory "app/views/#{theme}"
         directory "app/views/layouts/#{theme}"
+        directory "app/templates/spina/#{theme}"
       end
       Spina::THEMES.clear
       Dir[Rails.root.join("config", "initializers", "themes", "*.rb")].each { |file| load file }

--- a/lib/generators/spina/templates/app/templates/spina/default/homepage.rb
+++ b/lib/generators/spina/templates/app/templates/spina/default/homepage.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Spina.define_template :homepage do
+  part :text, :text, title: "Body", hint: "Your main content"
+end

--- a/lib/generators/spina/templates/app/templates/spina/default/layout.rb
+++ b/lib/generators/spina/templates/app/templates/spina/default/layout.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Global layout parts are editable in the admin under Layout.
+# Uncomment one of the examples below, or add your own parts.
+#
+# Flat list:
+#
+# Spina.define_layout_parts do
+#   part :footer, :text, title: "Footer"
+# end
+#
+# Or split into tabs with sections (labels via spina.layout.sections.<name>):
+#
+# Spina.define_layout_parts do
+#   section :general do
+#     part :footer, :text, title: "Footer"
+#   end
+#
+#   section :seo do
+#     part :meta_title, :line
+#   end
+# end

--- a/lib/generators/spina/templates/app/templates/spina/default/show.rb
+++ b/lib/generators/spina/templates/app/templates/spina/default/show.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Spina.define_template :show do
+  title "Page"
+  part :text, :text, title: "Body", hint: "Your main content"
+end

--- a/lib/generators/spina/templates/app/templates/spina/demo/demo.rb
+++ b/lib/generators/spina/templates/app/templates/spina/demo/demo.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Spina.define_template :demo do
+  exclude_from %w[articles]
+  part :body, :text, hint: "Your content"
+  part :image_collection, :image_collection
+  part :image, :image
+  repeater :repeater, title: "Repeater", item_name: "item" do
+    part :line, :line
+    part :image, :image
+    part :headline, :line, hint: "Used in the header"
+  end
+end

--- a/lib/generators/spina/templates/app/templates/spina/demo/homepage.rb
+++ b/lib/generators/spina/templates/app/templates/spina/demo/homepage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Spina.define_template :homepage do
+  part :headline, :line, hint: "Used in the header"
+  part :body, :text, hint: "Your content"
+  part :image_collection, :image_collection
+end

--- a/lib/generators/spina/templates/app/templates/spina/demo/layout.rb
+++ b/lib/generators/spina/templates/app/templates/spina/demo/layout.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Global layout parts are editable in the admin under Layout.
+# Uncomment one of the examples below, or add your own parts.
+#
+# Flat list:
+#
+# Spina.define_layout_parts do
+#   part :footer, :text, title: "Footer"
+# end
+#
+# Or split into tabs with sections (labels via spina.layout.sections.<name>):
+#
+# Spina.define_layout_parts do
+#   section :general do
+#     part :footer, :text, title: "Footer"
+#   end
+#
+#   section :seo do
+#     part :meta_title, :line
+#   end
+# end

--- a/lib/generators/spina/templates/app/templates/spina/demo/show.rb
+++ b/lib/generators/spina/templates/app/templates/spina/demo/show.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Spina.define_template :show do
+  title "Default"
+  part :body, :text, hint: "Your content"
+  part :image, :image
+  repeater :repeater, title: "Repeater", item_name: "item" do
+    part :line, :line
+    part :image, :image
+    part :headline, :line, hint: "Used in the header"
+  end
+end

--- a/lib/generators/spina/templates/config/initializers/themes/default.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/default.rb
@@ -8,30 +8,9 @@ Spina::Theme.register do |theme|
   theme.name = "default"
   theme.title = "Default theme"
 
-  # Parts
-  # Define all editable parts you want to use in your view templates
-  #
-  # Built-in part types:
-  # - Line
-  # - MultiLine
-  # - Text (Rich text editor)
-  # - Image
-  # - ImageCollection
-  # - Attachment
-  # - Option
-  # - Repeater
-  theme.parts = [
-    {name: "text", title: "Body", hint: "Your main content", part_type: "Spina::Parts::Text"}
-  ]
-
-  # View templates
-  # Every page has a view template stored in app/views/my_theme/pages/*
-  # You define which parts you want to enable for every view template
-  # by referencing them from the theme.parts configuration above.
-  theme.view_templates = [
-    {name: "homepage", title: "Homepage", parts: %w[text]},
-    {name: "show", title: "Page", parts: %w[text]}
-  ]
+  # Page templates are defined in app/templates/spina/default/*.rb
+  # Global layout parts are defined in app/templates/spina/default/layout.rb
+  # theme.load_templates_from "app/templates/spina/default" # default location, can be overridden
 
   # Custom pages
   # Some pages should not be created by the user, but generated automatically.
@@ -47,10 +26,7 @@ Spina::Theme.register do |theme|
     {name: "main", label: "Main navigation"}
   ]
 
-  # Layout parts (optional)
-  # You can create global content that doesn't belong to one specific page. We call these layout parts.
-  # You only have to reference the name of the parts you want to have here.
-  theme.layout_parts = []
+  # Layout parts (optional) — define in app/templates/spina/default/layout.rb
 
   # Resources (optional)
   # Think of resources as a collection of pages. They are managed separately in Spina

--- a/lib/generators/spina/templates/config/initializers/themes/demo.rb
+++ b/lib/generators/spina/templates/config/initializers/themes/demo.rb
@@ -1,75 +1,21 @@
-# Theme configuration file
-# ========================
-# This file is used for all theme configuration.
-# It's where you define everything that's editable in Spina CMS.
+# frozen_string_literal: true
 
 Spina::Theme.register do |theme|
-  # All views are namespaced based on the theme's name
   theme.name = "demo"
   theme.title = "Demo theme"
 
-  # Parts
-  # Define all editable parts you want to use in your view templates
-  #
-  # Built-in part types:
-  # - Line
-  # - MultiLine
-  # - Text (Rich text editor)
-  # - Image
-  # - ImageCollection
-  # - Attachment
-  # - Option
-  # - Repeater
-  theme.parts = [
-    {name: "repeater", title: "Repeater", part_type: "Spina::Parts::Repeater", item_name: "item", parts: %w[line image headline]},
-    {name: "line", title: "Line", part_type: "Spina::Parts::Line"},
-    {name: "body", title: "Body", hint: "Your content", part_type: "Spina::Parts::Text"},
-    {name: "image_collection", title: "Image collection", part_type: "Spina::Parts::ImageCollection"},
-    {name: "image", title: "Image", part_type: "Spina::Parts::Image"},
-    {name: "headline", title: "Headline", hint: "Used in the header", part_type: "Spina::Parts::Line"},
-    {name: "footer", title: "Footer", part_type: "Spina::Parts::Text"}
-  ]
-
-  # View templates
-  # Every page has a view template stored in app/views/my_theme/pages/*
-  # You define which parts you want to enable for every view template
-  # by referencing them from the theme.parts configuration above.
-  theme.view_templates = [
-    {name: "homepage", title: "Homepage", parts: %w[headline body image_collection]},
-    {name: "show", title: "Default", parts: %w[body image repeater]},
-    {name: "demo", title: "Demo", parts: %w[body image_collection image repeater], exclude_from: %w[articles]}
-  ]
-
-  # Custom pages
-  # Some pages should not be created by the user, but generated automatically.
-  # By naming them you can reference them in your code.
   theme.custom_pages = [
     {name: "homepage", title: "Homepage", deletable: false, view_template: "homepage"},
     {name: "demo", title: "Demo", deletable: true, view_template: "demo"}
   ]
 
-  # Navigations (optional)
-  # If your project has multiple navigations, it can be useful to configure multiple
-  # navigations.
   theme.navigations = [
     {name: "main", label: "Main navigation"}
   ]
 
-  # Layout parts (optional)
-  # You can create global content that doesn't belong to one specific page. We call these layout parts.
-  # You only have to reference the name of the parts you want to have here.
-  theme.layout_parts = []
-
-  # Resources (optional)
-  # Think of resources as a collection of pages. They are managed separately in Spina
-  # allowing you to separate these pages from the 'main' collection of pages.
   theme.resources = [
     {name: "articles", label: "Articles", view_template: "article", slug: "articles"}
   ]
 
-  # Plugins (optional)
   theme.plugins = ["reviews"]
-
-  # Embeds (optional)
-  theme.embeds = []
 end

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -4,6 +4,14 @@ require "spina/admin_sectionable"
 require "spina/railtie"
 require "spina/theme_reloader"
 require "spina/plugin"
+require "spina/part_type"
+require "spina/part_definition_merge"
+require "spina/parts_definition"
+require "spina/layout_parts"
+require "spina/page_template"
+require "spina/page_template_loader"
+require "spina/page_templates_compiler"
+require "spina/theme_migrator"
 require "spina/theme"
 require "spina/attr_json_spina_parts_model"
 require "spina/attr_json_monkeypatch"
@@ -84,10 +92,18 @@ module Spina
       yield(configuration)
     end
 
+    def define_template(name, &block)
+      PageTemplate.define(name, &block)
+    end
+
+    def define_layout_parts(&block)
+      LayoutParts.define(&block)
+    end
+
     delegate :locales, to: :config
 
     def deprecator
-      ActiveSupport::Deprecation.new("", "Spina")
+      @deprecator ||= ActiveSupport::Deprecation.new("", "Spina")
     end
 
     def mounted_at

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -18,6 +18,10 @@ module Spina
 
     config.autoload_paths += %W[#{config.root}/lib]
 
+    initializer "spina.ignore_page_template_files" do
+      Rails.autoloaders.main.ignore(Rails.root.join("app/templates/spina"))
+    end
+
     config.to_prepare do
       unless Spina.config.disable_decorator_load
         Dir.glob(Rails.root + "app/decorators/**/*_decorator.rb").each do |decorator|

--- a/lib/spina/layout_parts.rb
+++ b/lib/spina/layout_parts.rb
@@ -1,0 +1,120 @@
+module Spina
+  class LayoutParts
+    class << self
+      def define(&block)
+        raise ArgumentError, "No theme set for LayoutParts.define" unless current_theme_name
+
+        definition = Definition.new(current_theme_name)
+        definition.instance_eval(&block)
+        register(definition)
+        definition
+      end
+
+      def register(definition)
+        synchronize { registry[current_theme_name] = definition }
+      end
+
+      def for_theme(theme_name)
+        synchronize { registry[theme_name.to_s] }
+      end
+
+      def clear_for_theme(theme_name)
+        synchronize { registry.delete(theme_name.to_s) }
+      end
+
+      def clear_all
+        synchronize do
+          registry.clear
+          self.current_theme_name = nil
+        end
+      end
+
+      def with_theme(theme_name)
+        previous = current_theme_name
+        self.current_theme_name = theme_name.to_s
+        yield
+      ensure
+        self.current_theme_name = previous
+      end
+
+      def current_theme_name
+        ActiveSupport::IsolatedExecutionState[:spina_layout_parts_theme]
+      end
+
+      def current_theme_name=(name)
+        if name.nil?
+          ActiveSupport::IsolatedExecutionState.delete(:spina_layout_parts_theme)
+        else
+          ActiveSupport::IsolatedExecutionState[:spina_layout_parts_theme] = name.to_s
+        end
+      end
+
+      private
+
+      def synchronize(&block)
+        mutex.synchronize(&block)
+      end
+
+      def mutex
+        @mutex
+      end
+
+      def registry
+        @registry
+      end
+    end
+
+    @mutex = Mutex.new
+    @registry = {}
+
+    class Definition
+      include PartsDefinition
+
+      attr_reader :theme_name, :part_names, :sections
+
+      def initialize(theme_name)
+        @theme_name = theme_name
+        @part_names = []
+        @part_definitions = {}
+        @sections = nil
+        @current_section = nil
+      end
+
+      def section(name, &block)
+        raise ArgumentError, "Section #{name} requires a block" unless block
+        raise ArgumentError, "Cannot nest layout part sections" if @current_section
+        raise ArgumentError, "Cannot mix unsectioned layout parts with sections" if @sections.nil? && @part_names.any?
+
+        @sections ||= {}
+        section_name = name.to_sym
+        @sections[section_name] ||= []
+        @current_section = section_name
+        instance_eval(&block)
+      ensure
+        @current_section = nil
+      end
+
+      def part(name, type, **options)
+        super
+        track_section_part!(name)
+      end
+
+      def repeater(name, **options, &block)
+        super
+        track_section_part!(name)
+      end
+
+      def layout_part_names
+        @sections.presence || @part_names
+      end
+
+      private
+
+      def track_section_part!(name)
+        return unless @current_section
+
+        @sections[@current_section] << name.to_s
+      end
+    end
+  end
+end

--- a/lib/spina/page_template.rb
+++ b/lib/spina/page_template.rb
@@ -1,0 +1,119 @@
+module Spina
+  class PageTemplate
+    class << self
+      def define(name, &block)
+        raise ArgumentError, "No theme set for PageTemplate.define" unless current_theme_name
+
+        definition = Definition.new(name.to_s, current_theme_name)
+        definition.instance_eval(&block)
+        register(definition)
+        definition
+      end
+
+      def register(definition)
+        synchronize do
+          (registry[current_theme_name] ||= {})[definition.name] = definition
+        end
+      end
+
+      def for_theme(theme_name)
+        synchronize do
+          registry[theme_name.to_s]&.values&.dup || []
+        end
+      end
+
+      def clear_for_theme(theme_name)
+        synchronize { registry.delete(theme_name.to_s) }
+      end
+
+      def clear_all
+        synchronize do
+          registry.clear
+          self.current_theme_name = nil
+        end
+        LayoutParts.clear_all
+      end
+
+      def with_theme(theme_name)
+        previous = current_theme_name
+        self.current_theme_name = theme_name.to_s
+        yield
+      ensure
+        self.current_theme_name = previous
+      end
+
+      def current_theme_name
+        ActiveSupport::IsolatedExecutionState[:spina_page_template_theme]
+      end
+
+      def current_theme_name=(name)
+        if name.nil?
+          ActiveSupport::IsolatedExecutionState.delete(:spina_page_template_theme)
+        else
+          ActiveSupport::IsolatedExecutionState[:spina_page_template_theme] = name.to_s
+        end
+      end
+
+      private
+
+      def synchronize(&block)
+        mutex.synchronize(&block)
+      end
+
+      def mutex
+        @mutex
+      end
+
+      def registry
+        @registry
+      end
+    end
+
+    @mutex = Mutex.new
+    @registry = {}
+
+    class Definition
+      include PartsDefinition
+
+      attr_reader :name, :theme_name, :part_names
+
+      def initialize(name, theme_name)
+        @name = name
+        @theme_name = theme_name
+        @part_names = []
+        @part_definitions = {}
+        @title = name.humanize
+      end
+
+      def title(value = nil)
+        return @title if value.nil?
+
+        @title = value
+      end
+
+      def description(value = nil)
+        return @description if value.nil?
+
+        @description = value
+      end
+
+      def usage(value = nil)
+        return @usage if value.nil?
+
+        @usage = value
+      end
+
+      def exclude_from(values = nil)
+        return @exclude_from if values.nil?
+
+        @exclude_from = values
+      end
+
+      def layout(value = nil)
+        return @layout if value.nil?
+
+        @layout = value
+      end
+    end
+  end
+end

--- a/lib/spina/page_template_loader.rb
+++ b/lib/spina/page_template_loader.rb
@@ -1,0 +1,32 @@
+module Spina
+  class PageTemplateLoader
+    class << self
+      def load(path, theme_name:)
+        absolute_path = Rails.root.join(path)
+        return unless absolute_path.directory?
+
+        PageTemplate.clear_for_theme(theme_name)
+        LayoutParts.clear_for_theme(theme_name)
+
+        PageTemplate.with_theme(theme_name) do
+          LayoutParts.with_theme(theme_name) do
+            layout_file = absolute_path.join("layout.rb")
+            load_template_file(layout_file) if layout_file.file?
+
+            absolute_path.glob("**/*.rb").sort.each do |file|
+              next if file.basename.to_s == "layout.rb"
+
+              load_template_file(file)
+            end
+          end
+        end
+      end
+
+      private
+
+      def load_template_file(file)
+        Kernel.load file.to_s
+      end
+    end
+  end
+end

--- a/lib/spina/page_templates_compiler.rb
+++ b/lib/spina/page_templates_compiler.rb
@@ -1,0 +1,53 @@
+module Spina
+  class PageTemplatesCompiler
+    attr_reader :layout_part_definitions, :view_templates, :layout_part_names
+
+    def initialize(page_templates, layout_parts: nil)
+      @page_templates = page_templates
+      @layout_parts = layout_parts
+      compile!
+    end
+
+    private
+
+    def compile!
+      @layout_part_definitions = compile_part_definitions(@layout_parts&.part_definitions || [])
+      @layout_part_names = @layout_parts&.layout_part_names || []
+      @view_templates = @page_templates.map { |template| build_view_template(template) }
+    end
+
+    def compile_part_definitions(definitions)
+      parts_by_name = {}
+
+      definitions.each do |definition|
+        merge_part_definition!(parts_by_name, definition)
+      end
+
+      parts_by_name.values
+    end
+
+    def merge_part_definition!(parts_by_name, definition)
+      name = definition[:name]
+      existing = parts_by_name[name]
+
+      if existing && !PartDefinitionMerge.compatible?(existing, definition)
+        raise ArgumentError, "Part #{name.inspect} has conflicting definitions"
+      end
+
+      parts_by_name[name] = existing ? PartDefinitionMerge.merge_metadata(existing, definition) : definition.dup
+    end
+
+    def build_view_template(template)
+      {
+        name: template.name,
+        title: template.title,
+        parts: template.part_names
+      }.tap do |view_template|
+        view_template[:description] = template.description if template.description
+        view_template[:usage] = template.usage if template.usage
+        view_template[:exclude_from] = template.exclude_from if template.exclude_from
+        view_template[:layout] = template.layout if template.layout
+      end
+    end
+  end
+end

--- a/lib/spina/part_definition_merge.rb
+++ b/lib/spina/part_definition_merge.rb
@@ -1,0 +1,16 @@
+module Spina
+  module PartDefinitionMerge
+    module_function
+
+    def compatible?(left, right)
+      left.slice(:part_type, :options, :item_name, :parts) == right.slice(:part_type, :options, :item_name, :parts)
+    end
+
+    def merge_metadata(existing, incoming)
+      existing.dup.tap do |merged|
+        merged[:title] ||= incoming[:title]
+        merged[:hint] ||= incoming[:hint]
+      end
+    end
+  end
+end

--- a/lib/spina/part_type.rb
+++ b/lib/spina/part_type.rb
@@ -1,0 +1,43 @@
+module Spina
+  class PartType
+    class UnknownPartType < ArgumentError; end
+
+    BUILT_IN = {
+      line: "Spina::Parts::Line",
+      multi_line: "Spina::Parts::MultiLine",
+      text: "Spina::Parts::Text",
+      image: "Spina::Parts::Image",
+      image_collection: "Spina::Parts::ImageCollection",
+      attachment: "Spina::Parts::Attachment",
+      option: "Spina::Parts::Option",
+      repeater: "Spina::Parts::Repeater",
+      page_link: "Spina::Parts::PageLink",
+      page: "Spina::Parts::PageLink",
+      resource_link: "Spina::Parts::ResourceLink",
+      page_group: "Spina::Parts::ResourceLink"
+    }.freeze
+
+    class << self
+      def resolve(type)
+        case type
+        when Symbol
+          BUILT_IN.fetch(type) { raise UnknownPartType, "Unknown part type: #{type.inspect}" }
+        when String
+          type
+        when Class
+          type.name
+        else
+          raise ArgumentError, "Part type must be a Symbol, String, or Class (got #{type.class})"
+        end
+      end
+
+      def symbol_for(class_name)
+        BUILT_IN.key(class_name)
+      end
+
+      def built_in?(class_name)
+        BUILT_IN.value?(class_name)
+      end
+    end
+  end
+end

--- a/lib/spina/parts_definition.rb
+++ b/lib/spina/parts_definition.rb
@@ -1,0 +1,108 @@
+module Spina
+  module PartsDefinition
+    def part(name, type, **options)
+      definition = build_part_definition(name, type, **options)
+      register_part_definition(definition)
+      part_names << definition[:name]
+    end
+
+    def repeater(name, **options, &block)
+      raise ArgumentError, "Repeater #{name} requires a block" unless block
+
+      builder = RepeaterBuilder.new
+      builder.instance_eval(&block)
+
+      builder.part_definitions.each do |definition|
+        register_part_definition(definition)
+      end
+
+      repeater_definition = {
+        name: name.to_s,
+        title: options[:title] || default_title(name),
+        part_type: PartType.resolve(:repeater),
+        parts: builder.part_names
+      }
+      repeater_definition[:item_name] = options[:item_name] if options[:item_name]
+      repeater_definition[:hint] = options[:hint] if options[:hint]
+      repeater_definition[:options] = options[:options] if options[:options]
+
+      register_part_definition(repeater_definition)
+      part_names << repeater_definition[:name]
+    end
+
+    def part_definitions
+      @part_definitions.values
+    end
+
+    private
+
+    def build_part_definition(name, type, **options)
+      {
+        name: name.to_s,
+        title: options[:title] || default_title(name),
+        part_type: PartType.resolve(type)
+      }.tap do |definition|
+        definition[:hint] = options[:hint] if options[:hint]
+        definition[:item_name] = options[:item_name] if options[:item_name]
+        definition[:options] = options[:options] if options[:options]
+        definition[:parts] = options[:parts] if options[:parts]
+      end
+    end
+
+    def register_part_definition(definition)
+      existing = @part_definitions[definition[:name]]
+      if existing && !PartDefinitionMerge.compatible?(existing, definition)
+        raise ArgumentError, "Part #{definition[:name].inspect} is defined differently in multiple places"
+      end
+
+      @part_definitions[definition[:name]] = existing ? PartDefinitionMerge.merge_metadata(existing, definition) : definition
+    end
+
+    def default_title(name)
+      name.to_s.humanize
+    end
+
+    class RepeaterBuilder
+      attr_reader :part_definitions, :part_names
+
+      def initialize
+        @part_definitions = []
+        @part_names = []
+      end
+
+      def part(name, type, **options)
+        definition = {
+          name: name.to_s,
+          title: options[:title] || name.to_s.humanize,
+          part_type: PartType.resolve(type)
+        }
+        definition[:hint] = options[:hint] if options[:hint]
+        definition[:options] = options[:options] if options[:options]
+
+        @part_definitions << definition
+        @part_names << definition[:name]
+      end
+
+      def repeater(name, **options, &block)
+        raise ArgumentError, "Repeater #{name} requires a block" unless block
+
+        nested = RepeaterBuilder.new
+        nested.instance_eval(&block)
+        @part_definitions.concat(nested.part_definitions)
+
+        definition = {
+          name: name.to_s,
+          title: options[:title] || name.to_s.humanize,
+          part_type: PartType.resolve(:repeater),
+          parts: nested.part_names
+        }
+        definition[:item_name] = options[:item_name] if options[:item_name]
+        definition[:hint] = options[:hint] if options[:hint]
+        definition[:options] = options[:options] if options[:options]
+
+        @part_definitions << definition
+        @part_names << definition[:name]
+      end
+    end
+  end
+end

--- a/lib/spina/theme.rb
+++ b/lib/spina/theme.rb
@@ -1,6 +1,6 @@
 module Spina
   class Theme
-    attr_accessor :name, :title, :parts, :page_parts, :structures, :view_templates, :layout_parts, :custom_pages, :plugins, :public_theme, :config, :navigations, :resources, :embeds
+    attr_accessor :name, :title, :parts, :page_parts, :structures, :view_templates, :layout_parts, :layout_part_definitions, :page_template_definitions, :custom_pages, :plugins, :public_theme, :config, :navigations, :resources, :embeds, :templates_path
 
     NewPageTemplate = Struct.new(:name, :title, :description, :recommended)
 
@@ -10,31 +10,60 @@ module Spina
       end
 
       def unregister(name)
-        theme = find_by_name(name)
-        all.delete(theme) if theme
+        synchronize do
+          theme = all.find { |registered| registered.name == name }
+          all.delete(theme) if theme
+        end
+        PageTemplate.clear_for_theme(name)
+        LayoutParts.clear_for_theme(name)
       end
 
       def find_by_name(name)
-        all.find { |theme| theme.name == name }
+        synchronize { all.find { |theme| theme.name == name } }
       end
 
       def register
         theme = ::Spina::Theme.new
         yield theme
         raise "Missing theme name" if theme.name.nil?
-        unregister(theme.name)
-        if theme.plugins.nil?
-          theme.plugins = ::Spina::Plugin.all.map { |plugin| plugin.name }
+
+        synchronize do
+          existing = all.find { |registered| registered.name == theme.name }
+          all.delete(existing) if existing
+          PageTemplate.clear_for_theme(theme.name)
+          LayoutParts.clear_for_theme(theme.name)
+
+          theme.load_page_templates!
+          if theme.plugins.nil?
+            theme.plugins = ::Spina::Plugin.all.map { |plugin| plugin.name }
+          end
+          all << theme
         end
-        all << theme
+      end
+
+      def legacy_theme_warnings
+        @legacy_theme_warnings ||= Set.new
+      end
+
+      private
+
+      def synchronize(&block)
+        mutex.synchronize(&block)
+      end
+
+      def mutex
+        @mutex
       end
     end
+
+    @mutex = Mutex.new
 
     def initialize
       @page_parts = []
       @structures = []
       @layout_parts = []
       @view_templates = []
+      @page_template_definitions = {}
       @custom_pages = []
       @navigations = []
       @resources = []
@@ -66,6 +95,101 @@ module Spina
     # Check if view_template is defined as a custom undeletable page
     def is_custom_undeletable_page?(view_template_name)
       @custom_pages.any? { |page| page[:view_template] == view_template_name && !page[:deletable] }
+    end
+
+    def load_templates_from(path = nil)
+      @templates_path = path if path
+      @templates_path
+    end
+
+    def load_page_templates!
+      path = @templates_path || default_templates_path
+      ignore_templates_path!(path)
+      PageTemplateLoader.load(path, theme_name: name)
+
+      page_templates = PageTemplate.for_theme(name)
+      layout_parts_definition = LayoutParts.for_theme(name)
+
+      if page_templates.empty? && layout_parts_definition.nil?
+        @page_template_definitions = {}
+        warn_legacy_theme_config! if legacy_parts_config?
+        return
+      end
+
+      if legacy_parts_config?
+        raise ArgumentError, legacy_and_template_files_conflict_message(path)
+      end
+
+      compiled = PageTemplatesCompiler.new(page_templates, layout_parts: layout_parts_definition)
+      @parts = []
+      @page_template_definitions = page_templates.to_h { |template| [template.name, template.part_definitions] }
+      @layout_part_definitions = compiled.layout_part_definitions
+      @view_templates = compiled.view_templates
+      @layout_parts = compiled.layout_part_names if compiled.layout_part_names.any?
+    end
+
+    def part_definitions_for(context, view_template: nil)
+      case context
+      when :layout
+        layout_part_definitions.presence || parts
+      else
+        if uses_page_templates? && view_template.present?
+          page_template_definitions(view_template)
+        else
+          parts
+        end
+      end
+    end
+
+    def uses_page_templates?
+      @page_template_definitions.present?
+    end
+
+    def page_template_definitions(view_template)
+      @page_template_definitions[view_template.to_s] || []
+    end
+
+    private
+
+    def warn_legacy_theme_config!
+      return if Theme.legacy_theme_warnings.include?(name)
+
+      Theme.legacy_theme_warnings << name
+
+      Spina.deprecator.warn(<<~MESSAGE.squish)
+        Defining theme.parts and theme.view_templates in config/initializers/themes/#{name}.rb is deprecated
+        and will be removed in a future major version of Spina. Move page part definitions to
+        #{default_templates_path}/*.rb using Spina.define_template, and global layout parts to
+        #{default_templates_path}/layout.rb using Spina.define_layout_parts.
+        Run `bin/rails spina:theme:migrate_templates[#{name}]` to migrate automatically.
+      MESSAGE
+    end
+
+    def legacy_and_template_files_conflict_message(templates_path)
+      <<~MESSAGE
+        Theme #{name.inspect} uses both the legacy theme configuration and page template files.
+
+        Remove `theme.parts` and `theme.view_templates` from config/initializers/themes/#{name}.rb.
+        Part definitions belong in #{templates_path}/ (Spina.define_template and Spina.define_layout_parts).
+
+        Run `bin/rails spina:theme:migrate_templates[#{name}]` to migrate automatically.
+        Your original initializer will be backed up to #{ThemeMigrator.initializer_backup_path(name)}.
+      MESSAGE
+    end
+
+    def default_templates_path
+      "app/templates/spina/#{name}"
+    end
+
+    def ignore_templates_path!(path)
+      return unless defined?(Rails) && Rails.application
+
+      absolute_path = Rails.root.join(path)
+      Rails.autoloaders.main.ignore(absolute_path) if absolute_path.directory?
+    end
+
+    def legacy_parts_config?
+      parts.present? || view_templates.present?
     end
   end
 end

--- a/lib/spina/theme_migrator.rb
+++ b/lib/spina/theme_migrator.rb
@@ -1,0 +1,257 @@
+module Spina
+  class ThemeMigrator
+    INITIALIZER_BACKUP_EXTENSION = ".rb.bak"
+    MissingPartError = Class.new(ArgumentError)
+
+    def self.initializer_backup_path(theme_name, root: nil)
+      relative = "config/initializers/themes/#{theme_name}#{INITIALIZER_BACKUP_EXTENSION}"
+      root ? root.join(relative) : relative
+    end
+
+    def initialize(theme)
+      @theme = theme
+      @parts_by_name = theme.parts.index_by { |part| part[:name].to_s }
+    end
+
+    def migrate_to(output_dir = nil)
+      validate_part_references!
+
+      output_path = Rails.root.join(output_dir || templates_path)
+      FileUtils.mkdir_p(output_path)
+
+      written_files = []
+      begin
+        if @theme.layout_parts.present?
+          written_files << write_layout_file(output_path)
+        end
+
+        @theme.view_templates.each do |view_template|
+          written_files << write_template_file(output_path, view_template)
+        end
+      rescue
+        written_files.each { |path| FileUtils.rm_f(path) }
+        raise
+      end
+
+      output_path
+    end
+
+    def templates_path
+      "app/templates/spina/#{@theme.name}"
+    end
+
+    def slim_initializer_content
+      lines = []
+      lines << "# frozen_string_literal: true"
+      lines << ""
+      lines << "Spina::Theme.register do |theme|"
+      lines << "  theme.name = #{@theme.name.inspect}"
+      lines << "  theme.title = #{@theme.title.inspect}"
+      lines << "  theme.load_templates_from #{templates_path.inspect}"
+      lines << "  # Global layout parts are defined in #{templates_path}/layout.rb"
+      lines << ""
+
+      append_hash_array_assignment(lines, "custom_pages", @theme.custom_pages)
+      append_hash_array_assignment(lines, "navigations", @theme.navigations)
+      append_hash_array_assignment(lines, "resources", @theme.resources)
+      append_array_assignment(lines, "embeds", @theme.embeds)
+
+      if @theme.plugins.present?
+        lines << "  theme.plugins = #{@theme.plugins.inspect}"
+      end
+
+      lines << "end"
+      lines.join("\n") + "\n"
+    end
+
+    private
+
+    def validate_part_references!
+      missing = referenced_part_names.reject { |name| @parts_by_name.key?(name) }
+      return if missing.empty?
+
+      raise MissingPartError, <<~MESSAGE.squish
+        Theme #{@theme.name.inspect} references undefined parts: #{missing.sort.map(&:inspect).join(", ")}.
+        Add them to theme.parts before migrating.
+      MESSAGE
+    end
+
+    def referenced_part_names
+      names = []
+
+      each_layout_part_name do |part_name|
+        collect_part_names(part_name, names)
+      end
+
+      Array(@theme.view_templates).each do |view_template|
+        Array(view_template[:parts]).each do |part_name|
+          collect_part_names(part_name, names)
+        end
+      end
+
+      names.uniq
+    end
+
+    def each_layout_part_name(&block)
+      case @theme.layout_parts
+      when Hash
+        @theme.layout_parts.each_value do |part_names|
+          Array(part_names).each(&block)
+        end
+      else
+        Array(@theme.layout_parts).each(&block)
+      end
+    end
+
+    def collect_part_names(part_name, names)
+      name = part_name.to_s
+      return if names.include?(name)
+
+      names << name
+      definition = @parts_by_name[name]
+      return unless definition && definition[:parts]
+
+      definition[:parts].each { |sub_part_name| collect_part_names(sub_part_name, names) }
+    end
+
+    def write_layout_file(output_path)
+      filename = output_path.join("layout.rb")
+      File.write(filename, render_layout_file)
+      filename
+    end
+
+    def render_layout_file
+      lines = []
+      lines << "# frozen_string_literal: true"
+      lines << ""
+      lines << "Spina.define_layout_parts do"
+
+      case @theme.layout_parts
+      when Hash
+        @theme.layout_parts.each do |section_name, part_names|
+          lines << "  section #{section_name.to_sym.inspect} do"
+          Array(part_names).each do |part_name|
+            lines.concat(render_part_lines(part_name, indent: 2))
+          end
+          lines << "  end"
+        end
+      else
+        @theme.layout_parts.each do |part_name|
+          lines.concat(render_part_lines(part_name))
+        end
+      end
+
+      lines << "end"
+      lines.join("\n") + "\n"
+    end
+
+    def write_template_file(output_path, view_template)
+      filename = output_path.join("#{view_template[:name]}.rb")
+      File.write(filename, render_template_file(view_template))
+      filename
+    end
+
+    def render_template_file(view_template)
+      lines = []
+      lines << "# frozen_string_literal: true"
+      lines << ""
+      lines << "Spina.define_template #{view_template[:name].inspect} do"
+
+      append_metadata_line(lines, "title", view_template[:title], default: view_template[:name].to_s.humanize)
+      append_metadata_line(lines, "description", view_template[:description])
+      append_metadata_line(lines, "usage", view_template[:usage])
+      append_metadata_line(lines, "exclude_from", view_template[:exclude_from])
+      append_metadata_line(lines, "layout", view_template[:layout])
+
+      lines << "" if lines.last != "Spina.define_template #{view_template[:name].inspect} do"
+
+      view_template[:parts].each do |part_name|
+        lines.concat(render_part_lines(part_name))
+      end
+
+      lines << "end"
+      lines.join("\n") + "\n"
+    end
+
+    def render_part_lines(part_name, indent: 1)
+      definition = @parts_by_name.fetch(part_name.to_s)
+
+      if definition[:part_type] == "Spina::Parts::Repeater"
+        render_repeater_lines(definition, indent: indent)
+      else
+        [render_part_line(definition, indent: indent)]
+      end
+    end
+
+    def render_repeater_lines(definition, indent: 1)
+      prefix = "  " * indent
+      lines = []
+      options = part_options(definition)
+      line = "#{prefix}repeater #{definition[:name].inspect}"
+      line += ", #{format_options(options)}" if options.any?
+      lines << "#{line} do"
+
+      definition[:parts].each do |sub_part_name|
+        lines.concat(render_part_lines(sub_part_name, indent: indent + 1))
+      end
+
+      lines << "#{prefix}end"
+      lines
+    end
+
+    def render_part_line(definition, indent: 1)
+      "#{"  " * indent}#{render_part_call(definition)}"
+    end
+
+    def render_part_call(definition)
+      type = format_part_type(definition[:part_type])
+      options = part_options(definition)
+      call = "part #{definition[:name].inspect}, #{type}"
+      call += ", #{format_options(options)}" if options.any?
+      call
+    end
+
+    def format_part_type(part_type)
+      symbol = PartType.symbol_for(part_type)
+      symbol ? ":#{symbol}" : part_type.inspect
+    end
+
+    def part_options(definition)
+      options = {}
+      options[:title] = definition[:title] if definition[:title].present? && definition[:title] != definition[:name].to_s.humanize
+      options[:hint] = definition[:hint] if definition[:hint].present?
+      options[:item_name] = definition[:item_name] if definition[:item_name].present?
+      options[:options] = definition[:options] if definition[:options].present?
+      options
+    end
+
+    def format_options(options)
+      options.map { |key, value| "#{key}: #{value.inspect}" }.join(", ")
+    end
+
+    def append_metadata_line(lines, method_name, value, default: nil)
+      return if value.blank?
+      return if default && value == default
+
+      lines << "  #{method_name} #{value.inspect}"
+    end
+
+    def append_array_assignment(lines, attribute, values)
+      return if values.blank?
+
+      lines << "  theme.#{attribute} = #{values.inspect}"
+      lines << ""
+    end
+
+    def append_hash_array_assignment(lines, attribute, values)
+      return if values.blank?
+
+      lines << "  theme.#{attribute} = ["
+      values.each do |value|
+        lines << "    #{value.inspect},"
+      end
+      lines << "  ]"
+      lines << ""
+    end
+  end
+end

--- a/lib/spina/theme_reloader.rb
+++ b/lib/spina/theme_reloader.rb
@@ -2,18 +2,42 @@ class Spina::ThemeReloader
   delegate :execute_if_updated, :execute, :updated?, to: :updater
 
   def reload!
-    theme_paths.each { |path| load path }
+    Spina::PageTemplate.clear_all
+    theme_initializer_paths.each { |path| load path }
+    # Rebuild so custom theme.load_templates_from paths picked up during reload are watched.
+    @updater = nil
   end
 
   private
 
   def updater
-    @updater ||= Rails.application.config.file_watcher.new(theme_paths) do
+    @updater ||= Rails.application.config.file_watcher.new([], watched_dirs) do
       reload!
     end
   end
 
-  def theme_paths
-    Rails.root.glob("config/initializers/themes/*.rb")
+  def watched_dirs
+    dirs = {}
+    add_watched_dir!(dirs, Rails.root.join("config/initializers/themes"), ["rb"])
+    add_watched_dir!(dirs, Rails.root.join("app/templates/spina"), ["rb"])
+
+    Spina::Theme.all.each do |theme|
+      next if theme.templates_path.blank?
+
+      add_watched_dir!(dirs, Rails.root.join(theme.templates_path), ["rb"])
+    end
+
+    dirs
+  end
+
+  def add_watched_dir!(dirs, path, extensions)
+    path = path.to_s
+    return unless File.directory?(path)
+
+    dirs[path] = extensions
+  end
+
+  def theme_initializer_paths
+    Rails.root.glob("config/initializers/themes/*.rb").sort
   end
 end

--- a/lib/tasks/theme.rake
+++ b/lib/tasks/theme.rake
@@ -1,0 +1,33 @@
+namespace :spina do
+  namespace :theme do
+    desc "Migrate a theme initializer to page template files (usage: spina:theme:migrate_templates[theme_name])"
+    task :migrate_templates, [:theme_name] => :environment do |_task, args|
+      theme_name = args[:theme_name].presence || Spina::Account.first&.theme || "default"
+      theme = Spina::Theme.find_by_name(theme_name)
+
+      unless theme
+        abort "Theme #{theme_name.inspect} not found. Register it in config/initializers/themes first."
+      end
+
+      if theme.parts.blank? || theme.view_templates.blank?
+        abort "Theme #{theme_name.inspect} has no legacy theme.parts/theme.view_templates to migrate."
+      end
+
+      migrator = Spina::ThemeMigrator.new(theme)
+      path = migrator.migrate_to
+
+      initializer_path = Rails.root.join("config/initializers/themes/#{theme_name}.rb")
+      backup_path = Spina::ThemeMigrator.initializer_backup_path(theme_name, root: Rails.root)
+
+      if File.exist?(initializer_path)
+        FileUtils.cp(initializer_path, backup_path)
+        File.write(initializer_path, migrator.slim_initializer_content)
+      end
+
+      puts "Migrated #{theme.view_templates.size} page templates to #{path}"
+      puts "Updated #{initializer_path}"
+      puts "Removed theme.parts and theme.view_templates from the theme initializer."
+      puts "Backup saved to #{backup_path}" if File.exist?(backup_path)
+    end
+  end
+end

--- a/test/dummy/app/templates/spina/default/homepage.rb
+++ b/test/dummy/app/templates/spina/default/homepage.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Spina.define_template :homepage do
+  title "Homepage"
+  part :text, :text, title: "Text", hint: "Your main content"
+end

--- a/test/dummy/app/templates/spina/default/show.rb
+++ b/test/dummy/app/templates/spina/default/show.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Spina.define_template :show do
+  title "Default"
+  description "A simple page"
+  usage "Use for your content"
+  part :text, :text, title: "Text", hint: "Your main content"
+  part :attachment, :attachment, title: "Attachment"
+end

--- a/test/dummy/app/templates/spina/demo/blogpost.rb
+++ b/test/dummy/app/templates/spina/demo/blogpost.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Spina.define_template :blogpost do
+  description "Article template"
+  exclude_from %w[main]
+  part :body, :text
+end

--- a/test/dummy/app/templates/spina/demo/demo.rb
+++ b/test/dummy/app/templates/spina/demo/demo.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Spina.define_template :demo do
+  description "Example including all parts"
+  exclude_from %w[guides]
+  repeater :repeater do
+    part :line, :line
+    part :body, :text
+    part :image, :image
+    part :image_collection, :image_collection
+  end
+  repeater :repeater2, title: "Repeater", item_name: "item" do
+    part :line, :line
+    part :image, :image
+  end
+  part :attachment, :attachment
+  part :option, :option, options: [["Left", "left"], ["Center", "center"], ["Right", "right"]]
+  part :body, :text
+  part :image_collection, :image_collection
+  part :image, :image
+  part :portrait, :image, options: {ratio: "portrait"}
+  part :landscape, :image, options: {ratio: "landscape"}
+  part :wide, :image, options: {ratio: "wide"}
+  part :page_group, :resource_link, title: "Pagegroup"
+end

--- a/test/dummy/app/templates/spina/demo/different_layout.rb
+++ b/test/dummy/app/templates/spina/demo/different_layout.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Spina.define_template :different_layout do
+  layout "different_layout"
+  part :body, :text
+end

--- a/test/dummy/app/templates/spina/demo/homepage.rb
+++ b/test/dummy/app/templates/spina/demo/homepage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Spina.define_template :homepage do
+  part :headline, :line, hint: "This will be shown in your header"
+  part :body, :text
+  part :image_collection, :image_collection
+end

--- a/test/dummy/app/templates/spina/demo/layout.rb
+++ b/test/dummy/app/templates/spina/demo/layout.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Spina.define_layout_parts do
+  part :line, :line
+  part :body, :text
+  repeater :repeater do
+    part :line, :line
+    part :body, :text
+    part :image, :image
+    part :image_collection, :image_collection
+  end
+end

--- a/test/dummy/app/templates/spina/demo/show.rb
+++ b/test/dummy/app/templates/spina/demo/show.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Spina.define_template :show do
+  title "Simple page"
+  description "Default layout"
+  usage "Use for your content"
+  part :body, :text
+  part :blogpost, :page_link, title: "Blogpost", options: {resource: "blog"}
+  part :page, :page_link, title: "Pagina"
+  repeater :testrepeater, title: "Testrepeater" do
+    part :line, :line
+    part :body, :text
+  end
+  part :page_group, :resource_link, title: "Pagegroup"
+end

--- a/test/dummy/config/initializers/themes/default.rb
+++ b/test/dummy/config/initializers/themes/default.rb
@@ -1,29 +1,8 @@
-::Spina::Theme.register do |theme|
+# frozen_string_literal: true
+
+Spina::Theme.register do |theme|
   theme.name = "default"
   theme.title = "Default Theme"
-
-  theme.parts = [{
-    name: "text",
-    title: "Text",
-    hint: "Your main content",
-    part_type: "Spina::Parts::Text"
-  }, {
-    name: "attachment",
-    title: "Attachment",
-    part_type: "Spina::Parts::Attachment"
-  }]
-
-  theme.view_templates = [{
-    name: "homepage",
-    title: "Homepage",
-    parts: ["text"]
-  }, {
-    name: "show",
-    title: "Default",
-    description: "A simple page",
-    usage: "Use for your content",
-    parts: ["text", "attachment"]
-  }]
 
   theme.custom_pages = [{
     name: "homepage",

--- a/test/dummy/config/initializers/themes/demo.rb
+++ b/test/dummy/config/initializers/themes/demo.rb
@@ -1,126 +1,19 @@
-# Theme configuration
+# frozen_string_literal: true
+
 Spina::Theme.register do |theme|
   theme.name = "demo"
   theme.title = "Demo theme"
+
   theme.resources = [
     {name: "landing_pages", label: "Landing pages"},
     {name: "blog", label: "Blog"}
   ]
 
-  # All available parts
-  theme.parts = [{
-    name: "repeater",
-    title: "Repeater",
-    part_type: "Spina::Parts::Repeater",
-    parts: ["line", "body", "image", "image_collection"]
-  }, {
-    name: "repeater2",
-    title: "Repeater",
-    part_type: "Spina::Parts::Repeater",
-    item_name: "item",
-    parts: ["line", "image"]
-  }, {
-    name: "line",
-    title: "Line",
-    part_type: "Spina::Parts::Line"
-  }, {
-    name: "body",
-    title: "Body",
-    part_type: "Spina::Parts::Text"
-  }, {
-    name: "image_collection",
-    title: "Image collection",
-    part_type: "Spina::Parts::ImageCollection"
-  }, {
-    name: "image",
-    title: "Image",
-    part_type: "Spina::Parts::Image"
-  }, {name: "portrait", part_type: "Spina::Parts::Image", options: {ratio: "portrait"}}, {name: "landscape", part_type: "Spina::Parts::Image", options: {ratio: "landscape"}}, {name: "wide", part_type: "Spina::Parts::Image", options: {ratio: "wide"}}, {
-    name: "headline",
-    title: "Headline",
-    hint: "This will be shown in your header",
-    part_type: "Spina::Parts::Line"
-  }, {
-    name: "footer",
-    title: "Footer",
-    part_type: "Spina::Parts::Text"
-  }, {
-    name: "option",
-    title: "Option",
-    part_type: "Spina::Parts::Option",
-    options: [["Left", "left"], ["Center", "center"], ["Right", "right"]]
-  }, {
-    name: "attachment",
-    title: "Attachment",
-    part_type: "Spina::Parts::Attachment"
-  }, {
-    name: "testrepeater",
-    title: "Testrepeater",
-    part_type: "Spina::Parts::Repeater",
-    parts: %w[line body]
-  }, {
-    name: "page",
-    title: "Pagina",
-    part_type: "Spina::Parts::PageLink"
-  }, {
-    name: "blogpost",
-    title: "Blogpost",
-    part_type: "Spina::Parts::PageLink",
-    options: {
-      resource: "blog"
-    }
-  }, {
-    name: "page_group",
-    title: "Pagegroup",
-    part_type: "Spina::Parts::ResourceLink",
-  }]
-
-  theme.view_templates = [{
-    name: "homepage",
-    title: "Homepage",
-    parts: ["headline", "body", "image_collection"]
-  }, {
-    name: "show",
-    title: "Simple page",
-    description: "Default layout",
-    usage: "Use for your content",
-    parts: ["body", "blogpost", "page", "testrepeater", "page_group"]
-  }, {
-    name: "demo",
-    title: "Demo",
-    description: "Example including all parts",
-    parts: ["repeater", "repeater2", "attachment", "option", "body", "image_collection", "image", "portrait", "landscape", "wide", "page_group"],
-    exclude_from: %w[guides]
-  }, {
-    name: "blogpost",
-    title: "Blogpost",
-    description: "Article template",
-    parts: ["body"],
-    exclude_from: %w[main]
-  }, {
-    name: "different_layout",
-    title: "Different layout",
-    parts: %w[body],
-    layout: "different_layout"
-  }]
-
-  theme.custom_pages = [{
-    name: "homepage",
-    title: "Homepage",
-    deletable: false,
-    view_template: "homepage"
-  }, {
-    name: "demo",
-    title: "Demo",
-    deletable: true,
-    view_template: "demo"
-  }]
-
-  # Some global content
-  theme.layout_parts = ["line", "body", "repeater"]
+  theme.custom_pages = [
+    {name: "homepage", title: "Homepage", deletable: false, view_template: "homepage"},
+    {name: "demo", title: "Demo", deletable: true, view_template: "demo"}
+  ]
 
   theme.plugins = ["reviews"]
-
-  # Embeds
   theme.embeds = %w[button youtube vimeo]
 end

--- a/test/unit/spina/layout_parts_test.rb
+++ b/test/unit/spina/layout_parts_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+module Spina
+  class LayoutPartsTest < ActiveSupport::TestCase
+    setup do
+      LayoutParts.clear_all
+    end
+
+    teardown do
+      LayoutParts.clear_all
+    end
+
+    test "defines global layout parts" do
+      LayoutParts.with_theme("sample") do
+        LayoutParts.define do
+          part :tag_line, :line
+          part :footer_text, :text, title: "Footer Text"
+        end
+      end
+
+      definition = LayoutParts.for_theme("sample")
+
+      assert_equal %w[tag_line footer_text], definition.part_names
+      assert_equal "Spina::Parts::Line", definition.part_definitions.find { |p| p[:name] == "tag_line" }[:part_type]
+    end
+
+    test "Spina.define_layout_parts delegates to LayoutParts.define" do
+      LayoutParts.with_theme("sample") do
+        Spina.define_layout_parts do
+          part :footer, :text
+        end
+      end
+
+      definition = LayoutParts.for_theme("sample")
+      assert_equal %w[footer], definition.part_names
+    end
+
+    test "defines layout parts in sections" do
+      LayoutParts.with_theme("sample") do
+        LayoutParts.define do
+          section :general do
+            part :footer, :text
+          end
+
+          section :seo do
+            part :meta_title, :line
+          end
+        end
+      end
+
+      definition = LayoutParts.for_theme("sample")
+
+      assert_equal({general: %w[footer], seo: %w[meta_title]}, definition.layout_part_names)
+      assert_equal %w[footer meta_title], definition.part_names
+    end
+
+    test "raises when mixing unsectioned parts with sections" do
+      assert_raises(ArgumentError) do
+        LayoutParts.with_theme("sample") do
+          LayoutParts.define do
+            part :footer, :text
+            section :seo do
+              part :meta_title, :line
+            end
+          end
+        end
+      end
+    end
+
+    test "isolates current theme name per thread" do
+      ready = Queue.new
+      go = Queue.new
+      results = {}
+
+      threads = [
+        Thread.new do
+          LayoutParts.with_theme("tenant_a") do
+            ready << :a
+            go.pop
+            results[:a] = LayoutParts.current_theme_name
+            sleep 0.05
+            results[:a_after] = LayoutParts.current_theme_name
+          end
+        end,
+        Thread.new do
+          LayoutParts.with_theme("tenant_b") do
+            ready << :b
+            go.pop
+            results[:b] = LayoutParts.current_theme_name
+            sleep 0.05
+            results[:b_after] = LayoutParts.current_theme_name
+          end
+        end
+      ]
+
+      2.times { ready.pop }
+      2.times { go << true }
+      threads.each(&:join)
+
+      assert_equal "tenant_a", results[:a]
+      assert_equal "tenant_a", results[:a_after]
+      assert_equal "tenant_b", results[:b]
+      assert_equal "tenant_b", results[:b_after]
+    end
+  end
+end

--- a/test/unit/spina/page_template_test.rb
+++ b/test/unit/spina/page_template_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+module Spina
+  class PageTemplateTest < ActiveSupport::TestCase
+    setup do
+      PageTemplate.clear_all
+    end
+
+    teardown do
+      PageTemplate.clear_all
+    end
+
+    test "defines parts and repeaters" do
+      PageTemplate.with_theme("sample") do
+        PageTemplate.define :homepage do
+          title "Homepage"
+          description "Front page for the site"
+          part :header_background, :image
+          part :header_text, :text
+          part :hero_cta_link, :page_link
+          part :case_study, "MyApp::Parts::CaseStudy"
+          repeater :homepage_outcome_cards do
+            part :title, :line
+            part :image, :image
+            part :text, :text
+          end
+        end
+      end
+
+      template = PageTemplate.for_theme("sample").first
+
+      assert_equal "Homepage", template.title
+      assert_equal "Front page for the site", template.description
+      assert_equal %w[header_background header_text hero_cta_link case_study homepage_outcome_cards], template.part_names
+
+      parts_by_name = template.part_definitions.index_by { |part| part[:name] }
+      assert_equal "Spina::Parts::Image", parts_by_name["header_background"][:part_type]
+      assert_equal "MyApp::Parts::CaseStudy", parts_by_name["case_study"][:part_type]
+      assert_equal %w[title image text], parts_by_name["homepage_outcome_cards"][:parts]
+    end
+
+    test "allows the same part name with different definitions across page templates" do
+      PageTemplate.with_theme("sample") do
+        PageTemplate.define :first do
+          part :title, :line
+        end
+
+        PageTemplate.define :second do
+          part :title, :text
+        end
+      end
+
+      first = PageTemplate.for_theme("sample").find { |template| template.name == "first" }
+      second = PageTemplate.for_theme("sample").find { |template| template.name == "second" }
+
+      assert_equal "Spina::Parts::Line", first.part_definitions.find { |part| part[:name] == "title" }[:part_type]
+      assert_equal "Spina::Parts::Text", second.part_definitions.find { |part| part[:name] == "title" }[:part_type]
+    end
+
+    test "raises when the same part is defined differently within a page template" do
+      assert_raises(ArgumentError) do
+        PageTemplate.with_theme("sample") do
+          PageTemplate.define :homepage do
+            part :title, :line
+            part :title, :text
+          end
+        end
+      end
+    end
+
+    test "Spina.define_template delegates to PageTemplate.define" do
+      PageTemplate.with_theme("sample") do
+        Spina.define_template :homepage do
+          title "Homepage"
+          part :text, :text
+        end
+      end
+
+      template = PageTemplate.for_theme("sample").first
+      assert_equal "homepage", template.name
+      assert_equal "Homepage", template.title
+      assert_equal %w[text], template.part_names
+    end
+  end
+end

--- a/test/unit/spina/page_templates_compiler_test.rb
+++ b/test/unit/spina/page_templates_compiler_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+module Spina
+  class PageTemplatesCompilerTest < ActiveSupport::TestCase
+    setup do
+      PageTemplate.clear_all
+    end
+
+    teardown do
+      PageTemplate.clear_all
+    end
+
+    test "compiles page templates into view templates" do
+      PageTemplate.with_theme("sample") do
+        PageTemplate.define :homepage do
+          title "Homepage"
+          part :header_background, :image
+          repeater :homepage_outcome_cards do
+            part :title, :line
+            part :image, :image
+            part :text, :text
+          end
+        end
+
+        PageTemplate.define :show do
+          title "Content Page"
+          part :header_background, :image
+          part :text, :text
+        end
+      end
+
+      compiled = PageTemplatesCompiler.new(PageTemplate.for_theme("sample"))
+
+      assert_equal 2, compiled.view_templates.size
+
+      homepage = compiled.view_templates.find { |template| template[:name] == "homepage" }
+      assert_equal %w[header_background homepage_outcome_cards], homepage[:parts]
+    end
+
+    test "keeps layout part definitions separate from page templates" do
+      layout_parts = nil
+
+      LayoutParts.with_theme("sample") do
+        layout_parts = LayoutParts::Definition.new("sample")
+        layout_parts.part :footer_text, :text
+        layout_parts.part :tag_line, :line
+      end
+
+      PageTemplate.with_theme("sample") do
+        PageTemplate.define :homepage do
+          part :tag_line, :line
+          part :text, :text
+        end
+      end
+
+      compiled = PageTemplatesCompiler.new(PageTemplate.for_theme("sample"), layout_parts: layout_parts)
+
+      assert_equal %w[footer_text tag_line], compiled.layout_part_names
+      assert_equal 2, compiled.layout_part_definitions.size
+    end
+
+    test "compiles sectioned layout parts as a hash" do
+      layout_parts = LayoutParts::Definition.new("sample")
+      layout_parts.section :general do
+        part :footer, :text
+      end
+      layout_parts.section :seo do
+        part :meta_title, :line
+      end
+
+      compiled = PageTemplatesCompiler.new([], layout_parts: layout_parts)
+
+      assert_equal({general: %w[footer], seo: %w[meta_title]}, compiled.layout_part_names)
+      assert_equal %w[footer meta_title].sort, compiled.layout_part_definitions.map { |part| part[:name] }.sort
+    end
+
+    test "allows the same part name with different definitions in layout and page templates" do
+      layout_parts = LayoutParts::Definition.new("sample")
+      layout_parts.part :some_content, :text
+
+      PageTemplate.with_theme("sample") do
+        PageTemplate.define :homepage do
+          part :some_content, :line
+        end
+      end
+
+      compiled = PageTemplatesCompiler.new(PageTemplate.for_theme("sample"), layout_parts: layout_parts)
+      homepage = PageTemplate.for_theme("sample").first
+
+      layout_part = compiled.layout_part_definitions.find { |part| part[:name] == "some_content" }
+      page_part = homepage.part_definitions.find { |part| part[:name] == "some_content" }
+
+      assert_equal "Spina::Parts::Text", layout_part[:part_type]
+      assert_equal "Spina::Parts::Line", page_part[:part_type]
+    end
+
+    test "allows the same part name with different definitions across page templates" do
+      PageTemplate.with_theme("sample") do
+        PageTemplate.define :homepage do
+          part :some_content, :text
+        end
+
+        PageTemplate.define :show do
+          part :some_content, :line
+        end
+      end
+
+      homepage = PageTemplate.for_theme("sample").find { |template| template.name == "homepage" }
+      show = PageTemplate.for_theme("sample").find { |template| template.name == "show" }
+
+      homepage_part = homepage.part_definitions.find { |part| part[:name] == "some_content" }
+      show_part = show.part_definitions.find { |part| part[:name] == "some_content" }
+
+      assert_equal "Spina::Parts::Text", homepage_part[:part_type]
+      assert_equal "Spina::Parts::Line", show_part[:part_type]
+    end
+  end
+end

--- a/test/unit/spina/part_type_test.rb
+++ b/test/unit/spina/part_type_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+module Spina
+  class PartTypeTest < ActiveSupport::TestCase
+    test "resolves built-in symbols to class names" do
+      assert_equal "Spina::Parts::Line", PartType.resolve(:line)
+      assert_equal "Spina::Parts::Text", PartType.resolve(:text)
+      assert_equal "Spina::Parts::PageLink", PartType.resolve(:page_link)
+    end
+
+    test "passes through string class names" do
+      assert_equal "MyApp::Parts::CaseStudy", PartType.resolve("MyApp::Parts::CaseStudy")
+    end
+
+    test "resolves class constants" do
+      assert_equal "Spina::Parts::Image", PartType.resolve(Spina::Parts::Image)
+    end
+
+    test "raises for unknown symbols" do
+      assert_raises(PartType::UnknownPartType) do
+        PartType.resolve(:case_study)
+      end
+    end
+
+    test "symbol_for returns built-in symbol" do
+      assert_equal :image, PartType.symbol_for("Spina::Parts::Image")
+      assert_nil PartType.symbol_for("MyApp::Parts::CaseStudy")
+    end
+  end
+end

--- a/test/unit/spina/theme_migrator_test.rb
+++ b/test/unit/spina/theme_migrator_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+module Spina
+  class ThemeMigratorTest < ActiveSupport::TestCase
+    setup do
+      @theme = Theme.new
+      @theme.name = "demo"
+      @theme.title = "Demo theme"
+      @theme.layout_parts = %w[line body]
+      @theme.custom_pages = [{name: "homepage", title: "Homepage", deletable: false, view_template: "homepage"}]
+      @theme.parts = [
+        {name: "line", title: "Line", part_type: "Spina::Parts::Line"},
+        {name: "body", title: "Body", part_type: "Spina::Parts::Text"},
+        {name: "title", title: "Card title", part_type: "Spina::Parts::Line"},
+        {name: "image", title: "Image", part_type: "Spina::Parts::Image"},
+        {name: "alignment", title: "Alignment", part_type: "Spina::Parts::Option", options: %w[left right center]},
+        {name: "nested_items", title: "Nested items", part_type: "Spina::Parts::Repeater", parts: %w[title], item_name: "item", options: {max: 3}},
+        {name: "cards", title: "Cards", part_type: "Spina::Parts::Repeater", parts: %w[title image nested_items alignment]},
+        {name: "case_study", title: "Case Study", part_type: "MyApp::Parts::CaseStudy"}
+      ]
+      @theme.view_templates = [
+        {name: "homepage", title: "Homepage", description: "Front page", parts: %w[line body cards case_study]}
+      ]
+    end
+
+    test "generates page template files and slim initializer" do
+      output_dir = Rails.root.join("tmp/theme_migrator/demo")
+      FileUtils.rm_rf(output_dir)
+
+      migrator = ThemeMigrator.new(@theme)
+      migrator.migrate_to(output_dir)
+
+      layout = File.read(output_dir.join("layout.rb"))
+      assert_includes layout, "Spina.define_layout_parts do"
+      assert_includes layout, 'part "line", :line'
+      assert_includes layout, 'part "body", :text'
+
+      homepage = File.read(output_dir.join("homepage.rb"))
+      assert_includes homepage, 'Spina.define_template "homepage" do'
+      assert_includes homepage, 'description "Front page"'
+      refute_includes homepage, 'title "Homepage"'
+      assert_includes homepage, "part \"line\", :line"
+      assert_includes homepage, "part \"case_study\", \"MyApp::Parts::CaseStudy\""
+      assert_includes homepage, "repeater \"cards\" do"
+      assert_includes homepage, "part \"title\", :line, title: \"Card title\""
+      assert_includes homepage, "part \"alignment\", :option, options: [\"left\", \"right\", \"center\"]"
+      assert_match(/repeater "nested_items".*item_name: "item".*options:.*max.*do/, homepage)
+      assert_match(/repeater "nested_items".*\n\s+part "title"/, homepage)
+
+      initializer = migrator.slim_initializer_content
+      assert_includes initializer, 'theme.load_templates_from "app/templates/spina/demo"'
+      assert_includes initializer, "layout.rb"
+      refute_includes initializer, "theme.layout_parts"
+      refute_includes initializer, "theme.parts"
+      refute_includes initializer, "theme.view_templates"
+    ensure
+      FileUtils.rm_rf(Rails.root.join("tmp/theme_migrator"))
+    end
+
+    test "raises before writing files when a part reference is missing" do
+      output_dir = Rails.root.join("tmp/theme_migrator/missing")
+      FileUtils.rm_rf(output_dir)
+      @theme.view_templates = [
+        {name: "homepage", title: "Homepage", parts: %w[line missing_part]}
+      ]
+
+      error = assert_raises(ThemeMigrator::MissingPartError) do
+        ThemeMigrator.new(@theme).migrate_to(output_dir)
+      end
+
+      assert_includes error.message, "missing_part"
+      refute File.exist?(output_dir.join("homepage.rb"))
+    ensure
+      FileUtils.rm_rf(Rails.root.join("tmp/theme_migrator"))
+    end
+
+    test "migrates sectioned layout parts" do
+      output_dir = Rails.root.join("tmp/theme_migrator/sectioned")
+      FileUtils.rm_rf(output_dir)
+      @theme.name = "sectioned"
+      @theme.layout_parts = {general: %w[line], seo: %w[body]}
+      @theme.view_templates = []
+
+      ThemeMigrator.new(@theme).migrate_to(output_dir)
+
+      layout = File.read(output_dir.join("layout.rb"))
+      assert_includes layout, "section :general do"
+      assert_includes layout, 'part "line", :line'
+      assert_includes layout, "section :seo do"
+      assert_includes layout, 'part "body", :text'
+    ensure
+      FileUtils.rm_rf(Rails.root.join("tmp/theme_migrator"))
+    end
+  end
+end

--- a/test/unit/spina/theme_reloader_test.rb
+++ b/test/unit/spina/theme_reloader_test.rb
@@ -5,18 +5,30 @@ module Spina
     setup do
       @reloader = Spina::ThemeReloader.new
       @theme = Rails.root.join("config/initializers/themes/demo.rb")
+      @templates_dir = Rails.root.join("app/templates/spina/demo")
     end
 
     test "reload is triggered when theme changes" do
       assert_changes -> { @reloader.updated? }, from: false, to: true do
-        touch_theme
+        FileUtils.touch(@theme)
       end
     end
 
-    private
+    test "reload is triggered when a new template file is added" do
+      new_template = @templates_dir.join("_reloader_new_template.rb")
+      FileUtils.rm_f(new_template)
 
-    def touch_theme
-      FileUtils.touch(@theme)
+      begin
+        assert_changes -> { @reloader.updated? }, from: false, to: true do
+          File.write(new_template, <<~RUBY)
+            Spina.define_template :reloader_new_template do
+              part :body, :text
+            end
+          RUBY
+        end
+      ensure
+        FileUtils.rm_f(new_template)
+      end
     end
   end
 end

--- a/test/unit/spina/theme_test.rb
+++ b/test/unit/spina/theme_test.rb
@@ -1,0 +1,310 @@
+require "test_helper"
+
+module Spina
+  class ThemeTest < ActiveSupport::TestCase
+    setup do
+      PageTemplate.clear_all
+      LayoutParts.clear_all
+      @previous_themes = Theme.all.dup
+      Theme.all.clear
+    end
+
+    teardown do
+      PageTemplate.clear_all
+      LayoutParts.clear_all
+      Theme.all.clear
+      Theme.all.concat(@previous_themes)
+    end
+
+    test "page template files are ignored by zeitwerk" do
+      path = Rails.root.join("app/templates/spina/demo/homepage.rb")
+      assert path.exist?
+      assert Rails.autoloaders.main.__ignores?(path.to_s)
+    end
+
+    test "loads layout parts from layout.rb" do
+      templates_dir = Rails.root.join("test/fixtures/templates/sample")
+      FileUtils.mkdir_p(templates_dir)
+
+      File.write(templates_dir.join("layout.rb"), <<~RUBY)
+        Spina.define_layout_parts do
+          part :footer_text, :text
+        end
+      RUBY
+
+      File.write(templates_dir.join("homepage.rb"), <<~RUBY)
+        Spina.define_template :homepage do
+          part :text, :text
+        end
+      RUBY
+
+      Theme.register do |theme|
+        theme.name = "sample"
+        theme.title = "Sample Theme"
+        theme.load_templates_from templates_dir
+      end
+
+      theme = Theme.find_by_name("sample")
+
+      assert_equal %w[footer_text], theme.layout_parts
+      assert theme.layout_part_definitions.any? { |part| part[:name] == "footer_text" }
+      assert theme.part_definitions_for(:page, view_template: "homepage").any? { |part| part[:name] == "text" }
+      refute theme.part_definitions_for(:page, view_template: "homepage").any? { |part| part[:name] == "footer_text" }
+    ensure
+      FileUtils.rm_rf(templates_dir)
+    end
+
+    test "loads sectioned layout parts from layout.rb" do
+      templates_dir = Rails.root.join("test/fixtures/templates/sectioned")
+      FileUtils.mkdir_p(templates_dir)
+
+      File.write(templates_dir.join("layout.rb"), <<~RUBY)
+        Spina.define_layout_parts do
+          section :general do
+            part :footer, :text
+            part :logo, :image
+          end
+
+          section :seo do
+            part :footer, :text
+            part :meta_title, :line
+          end
+        end
+      RUBY
+
+      Theme.register do |theme|
+        theme.name = "sectioned"
+        theme.title = "Sectioned Theme"
+        theme.load_templates_from templates_dir
+      end
+
+      theme = Theme.find_by_name("sectioned")
+
+      assert_equal({general: %w[footer logo], seo: %w[footer meta_title]}, theme.layout_parts)
+      assert_equal %w[footer logo meta_title].sort, theme.layout_part_definitions.map { |part| part[:name] }.sort
+    ensure
+      FileUtils.rm_rf(templates_dir)
+    end
+
+    test "loads page templates from the default templates path" do
+      templates_dir = Rails.root.join("test/fixtures/templates/sample")
+      FileUtils.mkdir_p(templates_dir)
+
+      File.write(templates_dir.join("homepage.rb"), <<~RUBY)
+        Spina.define_template :homepage do
+          title "Homepage"
+          part :text, :text, title: "Body", hint: "Your main content"
+        end
+      RUBY
+
+      Theme.register do |theme|
+        theme.name = "sample"
+        theme.title = "Sample Theme"
+        theme.load_templates_from templates_dir
+      end
+
+      theme = Theme.find_by_name("sample")
+
+      assert_equal 1, theme.view_templates.size
+      assert_equal "homepage", theme.view_templates.first[:name]
+      assert_equal %w[text], theme.view_templates.first[:parts]
+
+      text_part = theme.part_definitions_for(:page, view_template: "homepage").find { |part| part[:name] == "text" }
+      assert_equal "Spina::Parts::Text", text_part[:part_type]
+      assert_equal "Body", text_part[:title]
+      assert_equal "Your main content", text_part[:hint]
+
+      PageTemplate.clear_all
+      text_part = theme.part_definitions_for(:page, view_template: "homepage").find { |part| part[:name] == "text" }
+      assert_equal "Spina::Parts::Text", text_part[:part_type]
+    ensure
+      FileUtils.rm_rf(Rails.root.join("test/fixtures/templates/sample"))
+    end
+
+    test "allows the same part name with different definitions across page templates" do
+      templates_dir = Rails.root.join("test/fixtures/templates/sample")
+      FileUtils.mkdir_p(templates_dir)
+
+      File.write(templates_dir.join("homepage.rb"), <<~RUBY)
+        Spina.define_template :homepage do
+          part :some_content, :text
+        end
+      RUBY
+
+      File.write(templates_dir.join("show.rb"), <<~RUBY)
+        Spina.define_template :show do
+          part :some_content, :line
+        end
+      RUBY
+
+      Theme.register do |theme|
+        theme.name = "sample"
+        theme.title = "Sample Theme"
+        theme.load_templates_from templates_dir
+      end
+
+      theme = Theme.find_by_name("sample")
+
+      homepage_part = theme.part_definitions_for(:page, view_template: "homepage").find { |part| part[:name] == "some_content" }
+      show_part = theme.part_definitions_for(:page, view_template: "show").find { |part| part[:name] == "some_content" }
+
+      assert_equal "Spina::Parts::Text", homepage_part[:part_type]
+      assert_equal "Spina::Parts::Line", show_part[:part_type]
+    ensure
+      FileUtils.rm_rf(templates_dir)
+    end
+
+    test "loads nested repeaters and preserves options keys" do
+      templates_dir = Rails.root.join("test/fixtures/templates/nested")
+      FileUtils.mkdir_p(templates_dir)
+
+      File.write(templates_dir.join("show.rb"), <<~RUBY)
+        Spina.define_template :show do
+          repeater :sections, options: {max: 5} do
+            part :heading, :line
+            repeater :items, item_name: "item" do
+              part :label, :line
+              part :alignment, :option, options: %w[left right]
+            end
+          end
+        end
+      RUBY
+
+      Theme.register do |theme|
+        theme.name = "nested"
+        theme.title = "Nested Theme"
+        theme.load_templates_from templates_dir
+      end
+
+      theme = Theme.find_by_name("nested")
+      parts = theme.part_definitions_for(:page, view_template: "show")
+
+      sections = parts.find { |part| part[:name] == "sections" }
+      items = parts.find { |part| part[:name] == "items" }
+      alignment = parts.find { |part| part[:name] == "alignment" }
+
+      assert_equal "Spina::Parts::Repeater", sections[:part_type]
+      assert_equal({max: 5}, sections[:options])
+      assert_equal %w[heading items], sections[:parts]
+      assert_equal "item", items[:item_name]
+      assert_equal %w[label alignment], items[:parts]
+      assert_equal %w[left right], alignment[:options]
+    ensure
+      FileUtils.rm_rf(templates_dir)
+    end
+
+    test "warns when legacy theme configuration is used" do
+      Theme.legacy_theme_warnings.delete("legacy-theme-test")
+
+      assert_deprecated do
+        Theme.register do |theme|
+          theme.name = "legacy-theme-test"
+          theme.title = "Legacy Theme"
+          theme.parts = [{name: "text", title: "Text", part_type: "Spina::Parts::Text"}]
+          theme.view_templates = [{name: "show", title: "Show", parts: %w[text]}]
+        end
+      end
+    end
+
+    test "concurrent theme registration keeps template registries isolated" do
+      templates_root = Rails.root.join("test/fixtures/templates")
+      FileUtils.mkdir_p(templates_root.join("tenant_a"))
+      FileUtils.mkdir_p(templates_root.join("tenant_b"))
+
+      File.write(templates_root.join("tenant_a/homepage.rb"), <<~RUBY)
+        Spina.define_template :homepage do
+          part :tenant_a_only, :text
+        end
+      RUBY
+
+      File.write(templates_root.join("tenant_b/homepage.rb"), <<~RUBY)
+        Spina.define_template :homepage do
+          part :tenant_b_only, :line
+        end
+      RUBY
+
+      ready = Queue.new
+      go = Queue.new
+      errors = []
+
+      threads = [
+        Thread.new do
+          ready << :a
+          go.pop
+          Theme.register do |theme|
+            theme.name = "tenant_a"
+            theme.title = "Tenant A"
+            theme.load_templates_from templates_root.join("tenant_a")
+          end
+        rescue => error
+          errors << error
+        end,
+        Thread.new do
+          ready << :b
+          go.pop
+          Theme.register do |theme|
+            theme.name = "tenant_b"
+            theme.title = "Tenant B"
+            theme.load_templates_from templates_root.join("tenant_b")
+          end
+        rescue => error
+          errors << error
+        end
+      ]
+
+      2.times { ready.pop }
+      2.times { go << true }
+      threads.each(&:join)
+
+      assert_empty errors
+
+      theme_a = Theme.find_by_name("tenant_a")
+      theme_b = Theme.find_by_name("tenant_b")
+
+      assert_equal %w[tenant_a_only], theme_a.view_templates.first[:parts]
+      assert_equal %w[tenant_b_only], theme_b.view_templates.first[:parts]
+      assert_equal "Spina::Parts::Text", theme_a.part_definitions_for(:page, view_template: "homepage").first[:part_type]
+      assert_equal "Spina::Parts::Line", theme_b.part_definitions_for(:page, view_template: "homepage").first[:part_type]
+    ensure
+      FileUtils.rm_rf(templates_root.join("tenant_a"))
+      FileUtils.rm_rf(templates_root.join("tenant_b"))
+    end
+
+    test "raises a clear error when legacy config and page template files both exist" do
+      templates_dir = Rails.root.join("test/fixtures/templates/conflict")
+      FileUtils.mkdir_p(templates_dir)
+
+      File.write(templates_dir.join("homepage.rb"), <<~RUBY)
+        Spina.define_template :homepage do
+          part :text, :text
+        end
+      RUBY
+
+      error = assert_raises(ArgumentError) do
+        Theme.register do |theme|
+          theme.name = "conflict"
+          theme.title = "Conflict Theme"
+          theme.parts = [{name: "text", title: "Text", part_type: "Spina::Parts::Text"}]
+          theme.load_templates_from templates_dir
+        end
+      end
+
+      assert_includes error.message, "uses both the legacy theme configuration and page template files"
+      assert_includes error.message, "Remove `theme.parts` and `theme.view_templates`"
+      assert_includes error.message, "spina:theme:migrate_templates[conflict]"
+      assert_includes error.message, "conflict.rb.bak"
+    ensure
+      FileUtils.rm_rf(Rails.root.join("test/fixtures/templates/conflict"))
+    end
+
+    private
+
+    def assert_deprecated(&block)
+      Spina.deprecator.expects(:warn).with do |message|
+        message.include?("theme.parts and theme.view_templates")
+      end.at_least_once
+
+      block.call
+    end
+  end
+end


### PR DESCRIPTION
Theme initializers had grown into long lists of parts and view templates that were hard to read and painful to maintain. This moves those definitions into app/templates/spina/{theme}/, one file per page template plus an optional layout.rb for site-wide parts. PageTemplate.define and LayoutParts.define provide a small DSL for declaring parts and repeaters. Built-in part types use symbols; custom parts keep their full class name as a string. At boot, Spina compiles these files into the same structures the admin already expects, so the rest of the engine stays largely unchanged.

Part definitions are scoped to their template (and separately for layout), so the same name can mean different things in different places without conflict. The old theme.parts and theme.view_templates configuration still works for now, with a deprecation warning and a spina:theme:migrate_templates task to convert existing themes. The migrator backs up the original initializer as .rb.bak so Rails won't load it.

The install generator and dummy app are updated to use the new layout.